### PR TITLE
feat(cli): add persistent writer mode

### DIFF
--- a/.changeset/cli-command-consistency.md
+++ b/.changeset/cli-command-consistency.md
@@ -1,0 +1,5 @@
+---
+"@cordn/cli": patch
+---
+
+Exit the interactive REPL cleanly on Ctrl+C, add the missing `publish-kp` command, fix option parsing for join requests, and keep command detection, help output, and bundled command documentation consistent from one catalog.

--- a/.changeset/persistent-cli-state.md
+++ b/.changeset/persistent-cli-state.md
@@ -1,5 +1,7 @@
 ---
 "@cordn/cli": minor
+"@cordn/coordinator": patch
+"@cordn/server": patch
 ---
 
-Add encrypted persistent MLS session state, non-interactive commands, and a daemon writer with file-based inbound and outbound queues.
+Add encrypted persistent CLI state, non-interactive commands, and a daemon writer with file-based queues. Make queued Welcome identifiers unique and exact StoreWelcome retries idempotent for reusable last-resort KeyPackages.

--- a/.changeset/persistent-cli-state.md
+++ b/.changeset/persistent-cli-state.md
@@ -1,0 +1,5 @@
+---
+"@cordn/cli": minor
+---
+
+Add encrypted persistent MLS session state, non-interactive commands, and a daemon writer with file-based inbound and outbound queues.

--- a/.changeset/persistent-cli-state.md
+++ b/.changeset/persistent-cli-state.md
@@ -1,7 +1,0 @@
----
-"@cordn/cli": minor
-"@cordn/coordinator": patch
-"@cordn/server": patch
----
-
-Publish the CLI as the `cordn` npm executable with hosted coordinator defaults and bundled offline documentation. Add encrypted persistent state, non-interactive commands, and a daemon writer with file-based queues. Make queued Welcome identifiers unique and exact StoreWelcome retries idempotent for reusable last-resort KeyPackages.

--- a/.changeset/persistent-cli-state.md
+++ b/.changeset/persistent-cli-state.md
@@ -4,4 +4,4 @@
 "@cordn/server": patch
 ---
 
-Add encrypted persistent CLI state, non-interactive commands, and a daemon writer with file-based queues. Make queued Welcome identifiers unique and exact StoreWelcome retries idempotent for reusable last-resort KeyPackages.
+Publish the CLI as the `cordn` npm executable with hosted coordinator defaults and bundled offline documentation. Add encrypted persistent state, non-interactive commands, and a daemon writer with file-based queues. Make queued Welcome identifiers unique and exact StoreWelcome retries idempotent for reusable last-resort KeyPackages.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,9 @@ jobs:
 
       - name: Run typecheck
         run: pnpm run typecheck
+
+      - name: Build distributable artifacts
+        run: pnpm run build:all
+
+      - name: Smoke-test the packed CLI
+        run: pnpm run pack:cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,10 @@ Packages (`packages/*`):
   message cursors, storage backends). Server-only; clients never embed it.
 - [`@cordn/server`](packages/server/src/) — ContextVM/MCP server bindings over
   the coordinator and the runnable server entrypoint.
-- [`@cordn/cli`](packages/cli/src/) — terminal client (REPL + session model) and
-  integration helpers. A leaf consumer; depends on `@cordn/core` (and on
-  `@cordn/server` + `@cordn/test-utils` in its integration tests).
+- [`@cordn/cli`](packages/cli/src/) — published `cordn` terminal client (REPL +
+  session model), persistent daemon, and integration helpers. A leaf consumer;
+  depends on `@cordn/core` (and on `@cordn/server` + `@cordn/test-utils` in its
+  integration tests).
 - [`@cordn/test-utils`](packages/test-utils/src/) — shared test fixtures: MLS
   artifact builders (`testUtils.ts`) and the mock Nostr relay (`mockRelay.ts`).
   A `devDependency` of every package whose tests need fixtures.
@@ -55,6 +56,7 @@ Coordinator contract notes:
 - Start the CLI client: `pnpm run client:cli`
 - Type-check: `pnpm run typecheck`
 - Build the server bundle: `pnpm run build`
+- Build the published CLI bundle: `pnpm run build:cli`
 - Run all tests: `pnpm run test`
 - Format source files: `pnpm run format`
 
@@ -64,7 +66,7 @@ Coordinator contract notes:
 - Runtime: Node.js (≥20) — runs `.ts` source directly via type-stripping
 - Main server entrypoint: [`packages/server/src/main.ts`](packages/server/src/main.ts)
 - Public exports: each package's `src/index.ts` barrel (e.g. [`packages/core/src/index.ts`](packages/core/src/index.ts)); there is no single root barrel
-- Build output: `dist/` (server bundle only)
+- Build outputs: `dist/main.js` (server) and `packages/cli/dist/cli.js` (published CLI)
 
 Environment notes for the server:
 
@@ -102,8 +104,8 @@ Agent expectations:
 
 ## Build and deployment
 
-- Production build uses [`pnpm run build`](package.json) and bundles [`packages/server/src/main.ts`](packages/server/src/main.ts) with esbuild (`--packages=external`). esbuild follows the root `tsconfig.json` `paths`, so `@cordn/*` packages are **inlined from source** into `dist/main.js`; only npm dependencies remain external.
-- Output is written to `dist/`
+- [`pnpm run build`](package.json) bundles the server to `dist/main.js`; `pnpm run build:cli` bundles the npm CLI to `packages/cli/dist/cli.js`. The release script runs both through `pnpm run build:all`.
+- The server bundle follows the root `tsconfig.json` `paths`, so `@cordn/*` packages are **inlined from source**. The CLI keeps published `@cordn/core` external and bundles its own source.
 - There is no separate deployment automation in this repository; deployment is currently a manual server-start flow
 
 ## PR and change guidance

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimal MLS delivery service coordinator and ContextVM server adapter implemente
 - [`spec/02.md`](spec/02.md) defines the Nostr-shaped application-message envelope model.
 - [`packages/coordinator/src/`](packages/coordinator/src/) contains the reference coordinator implementation.
 - [`packages/server/src/`](packages/server/src/) exposes that coordinator as a runnable ContextVM server.
-- [`packages/cli/src/`](packages/cli/src/) contains a demo CLI used to demonstrate end-to-end usage and interaction patterns.
+- [`@cordn/cli`](packages/cli/) is the published persistent client for interactive, scripted, and filesystem-queue agent workflows.
 - The same CLI and server flow is also used by the integration-style test coverage under [`packages/`](packages/).
 
 ## Coordinator delivery semantics
@@ -38,7 +38,19 @@ The reference client logic in [`packages/cli/src/`](packages/cli/src/) is intent
 - reconcile self-authored echoed ciphertext by identity instead of reprocessing it through MLS
 - finalize pending local epoch operations only after the matching inbound commit is observed
 
-These rules are documented in more detail in [`packages/cli/README.md`](packages/cli/README.md:54).
+These rules are documented in more detail in [`packages/cli/README.md`](packages/cli/README.md).
+
+## Install the CLI
+
+```bash
+npm install --global @cordn/cli
+cordn --version
+cordn docs quickstart
+```
+
+A fresh client defaults to coordinator `92753cbe63e943d0c4a0c61d745437892af6e98f179ce04a7a863aad4e00b1a5` through `wss://relay.contextvm.org`, `wss://relay2.contextvm.org`, and `wss://relay.primal.net`. Override these with `--server-pubkey` and `--relay`.
+
+The package bundles offline quickstart, agent, daemon, queue, and security documentation through `cordn docs`.
 
 ## Run the server locally
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cordn docs quickstart
 
 A fresh client defaults to coordinator `92753cbe63e943d0c4a0c61d745437892af6e98f179ce04a7a863aad4e00b1a5` through `wss://relay.contextvm.org`, `wss://relay2.contextvm.org`, and `wss://relay.primal.net`. Override these with `--server-pubkey` and `--relay`.
 
-The package bundles offline quickstart, agent, daemon, queue, and security documentation through `cordn docs`.
+The package bundles offline quickstart, command reference, agent, daemon, queue, and security documentation through `cordn docs`.
 
 ## Run the server locally
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
   "scripts": {
     "dev": "pnpm run server:start",
     "build": "esbuild ./packages/server/src/main.ts --bundle --outdir=./dist --target=node22 --format=esm --packages=external",
-    "release": "pnpm run build && changeset publish",
+    "build:cli": "pnpm --filter @cordn/cli run build",
+    "build:all": "pnpm run build && pnpm run build:cli",
+    "pack:cli": "pnpm --filter @cordn/cli run pack:check",
+    "release": "pnpm run build:all && changeset publish",
     "version": "changeset version",
     "typecheck": "tsc --noEmit",
     "client:cli": "node ./packages/cli/src/main.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @cordn/cli
 
+## 0.6.0
+
+### Minor Changes
+
+- 1c76cbb: Publish the CLI as the `cordn` npm executable with hosted coordinator defaults and bundled offline documentation. Add encrypted persistent state, non-interactive commands, and a daemon writer with file-based queues. Make queued Welcome identifiers unique and exact StoreWelcome retries idempotent for reusable last-resort KeyPackages.
+
 ## 0.5.3
 
 ### Patch Changes

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Cordn contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,6 +23,48 @@ Start the CLI with:
 pnpm run client:cli
 ```
 
+The default mode is an interactive REPL. A single command can also be run
+non-interactively:
+
+```sh
+pnpm run client:cli -- --private-key-file ./client.key --command "groups"
+```
+
+### Persistent writer mode
+
+The CLI can persist its identity, KeyPackages, Welcome records, MLS group
+state, cursors, and local message history in an AES-256-GCM encrypted file.
+The encryption key is created with mode `0600` when it does not exist.
+
+```sh
+pnpm run client:cli -- \
+  --private-key-file ./client.key \
+  --state-file ./state/session.json \
+  --state-key-file ./state/session.key \
+  --daemon \
+  --group-alias office \
+  --outbox-dir ./outbox \
+  --inbox-dir ./inbox
+```
+
+Daemon mode periodically fetches matching Welcomes, keeps joined groups in
+sync, and processes JSON outbox files in lexical filename order. Each job has
+this shape:
+
+```json
+{ "groupAlias": "office", "message": "hello" }
+```
+
+`groupAlias` may be omitted when `--group-alias` supplies a default. A job is
+removed only after the coordinator accepts the message and the updated MLS
+state has been persisted; failed jobs are returned to the queue for retry.
+Run the daemon under the host's service manager when automatic restart is
+required.
+
+With `--inbox-dir`, decrypted inbound group messages are written as atomic JSON
+jobs containing `groupAlias`, `cursor`, `sender`, `id`, `createdAt`, and
+`content`. Consumers can rename and remove these files after processing.
+
 Useful commands:
 
 - `gen-kp [alias]`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,14 +27,19 @@ The default mode is an interactive REPL. A single command can also be run
 non-interactively:
 
 ```sh
-pnpm run client:cli -- --private-key-file ./client.key --command "groups"
+pnpm run client:cli -- --server-pubkey <hex> --state-file ./state/session.json --command "groups"
 ```
 
 ### Persistent writer mode
 
 The CLI can persist its identity, KeyPackages, Welcome records, MLS group
-state, cursors, and local message history in an AES-256-GCM encrypted file.
-The encryption key is created with mode `0600` when it does not exist.
+state, cursors, local message history, pending epoch operations, coordinator
+routing, and acknowledgement state in an AES-256-GCM encrypted file. The
+hex-encoded 32-byte encryption key is created with mode `0600` when it does
+not exist. Startup fails if `--private-key`/`--private-key-file` conflicts with
+the stored identity. A state file is exclusively locked while in use: send
+work to a running daemon through its outbox instead of starting a second CLI
+against the same snapshot.
 
 ```sh
 pnpm run client:cli -- \
@@ -47,35 +52,41 @@ pnpm run client:cli -- \
   --inbox-dir ./inbox
 ```
 
-Daemon mode periodically fetches matching Welcomes, keeps joined groups in
-sync, and processes JSON outbox files in lexical filename order. Each job has
+Daemon mode requires `--state-file`, periodically fetches matching Welcomes,
+keeps joined groups in sync, and processes JSON outbox files in lexical
+filename order. Each job has
 this shape:
 
 ```json
 { "groupAlias": "office", "message": "hello" }
 ```
 
-`groupAlias` may be omitted when `--group-alias` supplies a default. A job is
-removed only after the coordinator accepts the message and the updated MLS
-state has been persisted; failed jobs are returned to the queue for retry.
-Run the daemon under the host's service manager when automatic restart is
-required.
+`groupAlias` may be omitted when `--group-alias` supplies a default. Use
+dedicated, separate inbox/outbox directories and never place state/key files
+in either queue. Producers must write to a non-`.json` temporary file and atomically
+rename it into the outbox when complete. A job is removed only after the coordinator accepts the
+message and the updated MLS state has been persisted; transient send failures
+are returned to the queue for retry, while malformed jobs are renamed to
+`<name>.json.invalid` so they cannot block later jobs. Jobs left behind as
+`<name>.json.processing` by a crash are adopted on the next pass. Delivery is
+at-least-once: a crash between send and removal can resend a job. Run the
+daemon under the host's service manager when automatic restart is required.
 
 With `--inbox-dir`, decrypted inbound group messages are written as atomic JSON
 jobs containing `groupAlias`, `cursor`, `sender`, `id`, `createdAt`, and
-`content`. Consumers can rename and remove these files after processing.
+`content`. Inbox delivery is also at-least-once: consumers should deduplicate by
+`groupAlias` + `cursor` + `id`, then rename and remove files after processing.
 
 Useful commands:
 
 - `gen-kp [alias]`
 - `key-packages` — inspect local key packages, including publish/consume state and metadata-extension support
-- `publish-kp <alias>`
 - `available-kps` — inspect coordinator-published key packages
 - `create-group <alias> [keyPackageAlias] [--watch]`
 - `create-group <alias> [keyPackageAlias] --name "Demo" --description "Shared group" --icon "🧵" --image-url "https://example.com/group.png"`
 - `update-group-metadata <groupAlias> --name "Demo" [--description "Shared group"] [--icon "🧵"] [--image-url "https://example.com/group.png"] [--admin <hex>]...`
 - `group <groupAlias> [--watch]`
-- `accept-welcome <keyPackageReference> [groupAlias] [--watch]`
+- `accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--watch]` — use the displayed `<coordinator>:<kp_ref>:<at>` ID when a reusable last-resort KeyPackage has multiple Welcomes
 - `groups` — compact list of joined groups, shared metadata, and watch status
 - `group-info [groupAlias]` — inspect one joined group's shared metadata and local state counters
 - `watch-all` — start background subscriptions for all joined groups
@@ -91,12 +102,12 @@ Useful commands:
 
 ## Notes
 
-- Group aliases are local convenience labels.
+- Group aliases are local convenience labels. A newer re-invite refreshes the existing group state and keeps its alias instead of creating a duplicate group ID.
 - Shared group presentation metadata is carried in MLS state through [`groupMetadata.ts`](src/groupMetadata.ts).
 - Key packages advertise support for the shared metadata extension, but they do not contain a group's actual shared metadata values.
 - Watching keeps a CEP-41 subscription alive in the background so watched groups stay locally synchronized without repeated bounded fetches.
 - Live messages are rendered immediately when a watched group is currently selected in the REPL.
-- This client is intentionally small and focused on development workflows rather than polished end-user UX.
+- This client is intentionally small and focused on reference/agent workflows rather than polished end-user UX.
 
 ## Encrypted media
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,6 +19,7 @@ The package includes version-matched offline documentation. These commands do no
 ```sh
 cordn docs
 cordn docs quickstart
+cordn docs commands
 cordn docs agent
 cordn docs daemon
 cordn docs queues
@@ -70,6 +71,7 @@ Useful commands include:
 status
 whoami
 gen-kp [alias] [--last-resort] [--local-only]
+publish-kp <alias> [--coordinator <pubkey>]
 key-packages
 available-kps
 create-group <alias> [keyPackageAlias] [--watch]
@@ -88,7 +90,10 @@ sync-all
 watch-all
 messages [groupAlias]
 issues [groupAlias]
+exit | quit
 ```
+
+Run `cordn docs commands` for the complete version-matched command reference.
 
 After selecting a group with `use`, plain text sends a message and an empty line synchronizes it. `whoami` prints the private identity key; prefer `status` unless explicit export is intended.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,131 +1,147 @@
-# CLI
+# @cordn/cli
 
-This directory contains the local [`cordn`](package.json) CLI client.
+Persistent MLS client for [Cordn](https://github.com/Cordn-msg/cordn). It supports an interactive REPL, one-shot commands, encrypted restart-safe state, live group watches, and durable filesystem queues for local agents and automations.
 
-It is intended for:
-
-- local development against a coordinator
-- integration testing of group creation, invites, welcomes, sync, and messaging
-- manual inspection of MLS-backed group behavior
-
-## Entry points
-
-- [`main.ts`](src/main.ts) — CLI startup
-- [`repl.ts`](src/repl.ts) — interactive terminal interface
-- [`session.ts`](src/session.ts) — in-memory client session model
-- [`groupMetadata.ts`](src/groupMetadata.ts) — `cordn_group_metadata` encoding and decoding
-
-## Usage
-
-Start the CLI with:
+## Install
 
 ```sh
-pnpm run client:cli
+npm install --global @cordn/cli
+cordn --version
+cordn --help
 ```
 
-The default mode is an interactive REPL. A single command can also be run
-non-interactively:
+Node.js 20.12 or newer is required.
+
+## Bundled documentation
+
+The package includes version-matched offline documentation. These commands do not require state, network access, or coordinator configuration:
 
 ```sh
-pnpm run client:cli -- --server-pubkey <hex> --state-file ./state/session.json --command "groups"
+cordn docs
+cordn docs quickstart
+cordn docs agent
+cordn docs daemon
+cordn docs queues
+cordn docs security
 ```
 
-### Persistent writer mode
+## Hosted default
 
-The CLI can persist its identity, KeyPackages, Welcome records, MLS group
-state, cursors, local message history, pending epoch operations, coordinator
-routing, and acknowledgement state in an AES-256-GCM encrypted file. The
-hex-encoded 32-byte encryption key is created with mode `0600` when it does
-not exist. Startup fails if `--private-key`/`--private-key-file` conflicts with
-the stored identity. A state file is exclusively locked while in use: send
-work to a running daemon through its outbox instead of starting a second CLI
-against the same snapshot.
+A fresh client uses:
+
+```text
+coordinator: 92753cbe63e943d0c4a0c61d745437892af6e98f179ce04a7a863aad4e00b1a5
+relays:
+  wss://relay.contextvm.org
+  wss://relay2.contextvm.org
+  wss://relay.primal.net
+```
+
+Override these with `--server-pubkey` and one or more `--relay` options. Persistent snapshots remember the coordinator and relays used to create them. Local development can continue deriving the coordinator public key from `CORDN_SERVER_PRIVATE_KEY` and reading comma-separated `CORDN_RELAY_URLS`.
+
+## Quickstart
 
 ```sh
-pnpm run client:cli -- \
-  --private-key-file ./client.key \
-  --state-file ./state/session.json \
-  --state-key-file ./state/session.key \
+STATE="${XDG_STATE_HOME:-$HOME/.local/state}/cordn/session.json"
+
+cordn --state-file "$STATE" --command status
+cordn --state-file "$STATE" --command "gen-kp main"
+cordn --state-file "$STATE" --command "create-group office"
+cordn --state-file "$STATE" --command "send-to office hello"
+cordn --state-file "$STATE" --command "messages office"
+```
+
+The first command generates a client identity and creates:
+
+- `$STATE` — AES-256-GCM encrypted identity, MLS state, cursors, and history
+- `$STATE.key` — the hex-encoded 32-byte snapshot encryption key
+
+Back up both files securely. Only one process may use a snapshot at a time.
+
+## Interactive mode
+
+```sh
+cordn --state-file "$STATE"
+```
+
+Useful commands include:
+
+```text
+status
+whoami
+gen-kp [alias] [--last-resort] [--local-only]
+key-packages
+available-kps
+create-group <alias> [keyPackageAlias] [--watch]
+groups
+group-info [groupAlias]
+use <groupAlias> [--watch]
+add-member <groupAlias> <stablePubkeyOrKeyPackageRef>
+remove-member <groupAlias> <stablePubkey>
+fetch-welcomes
+welcomes
+accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--watch]
+send <message...>
+send-to <groupAlias> <message...>
+sync [groupAlias]
+sync-all
+watch-all
+messages [groupAlias]
+issues [groupAlias]
+```
+
+After selecting a group with `use`, plain text sends a message and an empty line synchronizes it. `whoami` prints the private identity key; prefer `status` unless explicit export is intended.
+
+## One-shot mode
+
+```sh
+cordn --state-file "$STATE" --command "groups"
+cordn --state-file "$STATE" --command "sync office"
+cordn --state-file "$STATE" --command "send-to office hello"
+```
+
+Use `send-to` rather than `send`: selected-group context does not survive between processes.
+
+## Persistent daemon
+
+Bootstrap the identity and publish a KeyPackage before starting a long-running agent:
+
+```sh
+ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/cordn/agent"
+mkdir -p "$ROOT/inbox" "$ROOT/outbox"
+chmod 700 "$ROOT" "$ROOT/inbox" "$ROOT/outbox"
+
+cordn \
+  --state-file "$ROOT/session.json" \
   --daemon \
   --group-alias office \
-  --outbox-dir ./outbox \
-  --inbox-dir ./inbox
+  --outbox-dir "$ROOT/outbox" \
+  --inbox-dir "$ROOT/inbox"
 ```
 
-Daemon mode requires `--state-file`, periodically fetches matching Welcomes,
-keeps joined groups in sync, and processes JSON outbox files in lexical
-filename order. Each job has
-this shape:
+The daemon fetches matching Welcomes, accepts them using local KeyPackage material, catches groups up before watching, writes decrypted inbound messages to the inbox, and processes ordered JSON outbox jobs. It must be the sole writer of its snapshot.
 
-```json
-{ "groupAlias": "office", "message": "hello" }
-```
+Both queue directions are at-least-once. Producers must write a non-`.json` temporary file and atomically rename it into the outbox. Consumers must claim inbox records and deduplicate by `groupAlias + cursor + id`.
 
-`groupAlias` may be omitted when `--group-alias` supplies a default. Use
-dedicated, separate inbox/outbox directories and never place state/key files
-in either queue. Producers must write to a non-`.json` temporary file and atomically
-rename it into the outbox when complete. A job is removed only after the coordinator accepts the
-message and the updated MLS state has been persisted; transient send failures
-are returned to the queue for retry, while malformed jobs are renamed to
-`<name>.json.invalid` so they cannot block later jobs. Jobs left behind as
-`<name>.json.processing` by a crash are adopted on the next pass. Delivery is
-at-least-once: a crash between send and removal can resend a job. Run the
-daemon under the host's service manager when automatic restart is required.
-
-With `--inbox-dir`, decrypted inbound group messages are written as atomic JSON
-jobs containing `groupAlias`, `cursor`, `sender`, `id`, `createdAt`, and
-`content`. Inbox delivery is also at-least-once: consumers should deduplicate by
-`groupAlias` + `cursor` + `id`, then rename and remove files after processing.
-
-Useful commands:
-
-- `gen-kp [alias]`
-- `key-packages` — inspect local key packages, including publish/consume state and metadata-extension support
-- `available-kps` — inspect coordinator-published key packages
-- `create-group <alias> [keyPackageAlias] [--watch]`
-- `create-group <alias> [keyPackageAlias] --name "Demo" --description "Shared group" --icon "🧵" --image-url "https://example.com/group.png"`
-- `update-group-metadata <groupAlias> --name "Demo" [--description "Shared group"] [--icon "🧵"] [--image-url "https://example.com/group.png"] [--admin <hex>]...`
-- `group <groupAlias> [--watch]`
-- `accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--watch]` — use the displayed `<coordinator>:<kp_ref>:<at>` ID when a reusable last-resort KeyPackage has multiple Welcomes
-- `groups` — compact list of joined groups, shared metadata, and watch status
-- `group-info [groupAlias]` — inspect one joined group's shared metadata and local state counters
-- `watch-all` — start background subscriptions for all joined groups
-- `unwatch <groupAlias>` — stop one background subscription
-- `add-member <groupAlias> <stablePubkeyOrKeyPackageRef>`
-- `fetch-welcomes`
-- `fetch-join-requests <groupAlias>` — list pending join requests for a group
-- `request-join <gid> [keyPackageAlias] [--coordinator <pubkey>]` — send a join request for a group
-- `send <message...>`
-- `send-media <filePath> [caption...]` — requires `--media-dir <dir>`
-- `save-media [groupAlias] <cursor> [destDir]` — decrypts received media to `destDir` (default `.`)
-- `sync [groupAlias]`
-
-## Notes
-
-- Group aliases are local convenience labels. A newer re-invite refreshes the existing group state and keeps its alias instead of creating a duplicate group ID.
-- Shared group presentation metadata is carried in MLS state through [`groupMetadata.ts`](src/groupMetadata.ts).
-- Key packages advertise support for the shared metadata extension, but they do not contain a group's actual shared metadata values.
-- Watching keeps a CEP-41 subscription alive in the background so watched groups stay locally synchronized without repeated bounded fetches.
-- Live messages are rendered immediately when a watched group is currently selected in the REPL.
-- This client is intentionally small and focused on reference/agent workflows rather than polished end-user UX.
+Run `cordn docs queues` for exact schemas and crash behavior.
 
 ## Encrypted media
 
-The CLI can exchange encrypted media as defined in [`spec/applications/encrypted-media.md`](../../spec/applications/encrypted-media.md).
+Pass `--media-dir <path>` to enable `send-media` and `save-media`. Media is encrypted client-side using an MLS exporter-derived key and stored as an opaque content-addressed blob. Multiple local clients must share the same media directory for filesystem-backed exchange; a network content store is required across hosts.
 
-- Media is encrypted client-side with a key derived from the group's MLS exporter secret and stored as an opaque blob on a content-addressed `MediaStore`.
-- The coordinator is unchanged; only an `imeta` tag travels inside the sealed group message.
-- Pass `--media-dir <dir>` at startup to enable `send-media` / `save-media`. Two CLI processes on the same machine exchange media by pointing at the same directory (via [`FileMediaStore`](src/mediaStore.ts)). Blossom is the recommended production store.
+See the [encrypted-media specification](https://github.com/Cordn-msg/cordn/blob/master/spec/applications/encrypted-media.md).
 
-## Reference client algorithm
+## Development from the monorepo
 
-The CLI is intended to act as a reference client for the core local sync logic.
+```sh
+pnpm install
+pnpm run client:cli -- --state-file /tmp/cordn-session.json
+pnpm --filter @cordn/cli run build
+pnpm --filter @cordn/cli run pack:check
+```
 
-- Every group tracks a monotonic local fetch cursor.
-- Bounded catch-up still uses [`FetchGroupMessages()`](src/coordinatorClient.ts:331) or [`FetchManyGroupMessages()`](src/coordinatorClient.ts:342) as the canonical recovery API.
-- Watch mode follows a strict `fetch first, then subscribe` flow matching [`design/group-message-stream-subscription-plan.md`](design/group-message-stream-subscription-plan.md:200).
-- Clients watching many groups can replace multiple single-group subscribe calls with [`SubscribeManyGroupMessages()`](src/coordinatorClient.ts:371) after catch-up; streamed records keep the same shape and must still be ingested by `gid` with independent cursors.
-- Fetched backlog and streamed live records are both treated as the same raw group-message input and are processed through one shared ingestion pipeline in [`ingestGroupMessages()`](src/groupSync.ts:31).
-- Outbound self-echoes are reconciled by ciphertext identity instead of being MLS-processed again, so local send state is not corrupted by coordinator replay.
-- Pending epoch operations such as add-member commits are only finalized after the corresponding inbound commit is observed and classified by the ingestion pipeline.
-- Inbox records are retired explicitly rather than by observation. Accepting a welcome locally (or an admin resolving a fetched join request) queues a `consumed` ref that the next [`FetchPendingWelcomes()`](src/coordinatorClient.ts) / [`FetchPendingJoinRequests()`](src/coordinatorClient.ts) echoes back, so the coordinator retires the record. Records that are never acked fall to the max-age ceiling, never to a read timer.
+The reference sync implementation follows fetch-first-then-subscribe semantics, independent per-group cursors, one inbound ingestion path for catch-up and live records, ciphertext-based self-echo reconciliation, and inbound confirmation before pending epoch operations are finalized.
+
+## License
+
+MIT

--- a/packages/cli/docs/AGENT.md
+++ b/packages/cli/docs/AGENT.md
@@ -1,0 +1,96 @@
+# Agent usage
+
+Use the CLI directly for bounded operations and its filesystem queues for a continuously running integration.
+
+## Discover the installed interface
+
+```sh
+cordn --version
+cordn --help
+cordn docs
+cordn docs queues
+```
+
+Do not assume flags from a different installed version. These bundled documents are the local source of truth.
+
+## Bootstrap safely
+
+Choose paths outside source repositories and restrict their parent directory:
+
+```sh
+ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/cordn/agent"
+mkdir -p "$ROOT"
+chmod 700 "$ROOT"
+
+cordn --state-file "$ROOT/session.json" --command status
+```
+
+The default hosted coordinator is ready without additional flags. Use explicit `--server-pubkey` and `--relay` options only when targeting another deployment.
+
+Back up both `session.json` and `session.json.key`. Never print, transmit, or edit either file.
+
+## One-shot operations
+
+When no daemon owns the state:
+
+```sh
+cordn --state-file "$ROOT/session.json" --command "groups"
+cordn --state-file "$ROOT/session.json" --command "sync office"
+cordn --state-file "$ROOT/session.json" --command "messages office"
+cordn --state-file "$ROOT/session.json" --command "send-to office hello"
+```
+
+Use `send-to`; selected REPL group context does not persist between processes. Treat nonzero exit status as failure.
+
+Avoid `whoami` in agent workflows because it includes the private identity key. `status` exposes only the stable public key and local counts.
+
+## Invitations
+
+Before waiting for an invitation, publish a KeyPackage:
+
+```sh
+# One invitation
+cordn --state-file "$ROOT/session.json" --command "gen-kp agent-main"
+
+# Reusable across invitations
+cordn --state-file "$ROOT/session.json" \
+  --command "gen-kp agent-reusable --last-resort"
+```
+
+A long-running daemon automatically accepts matching Welcomes for locally held KeyPackages. It ignores Welcomes for which private KeyPackage material is unavailable.
+
+## Continuous operation
+
+```sh
+mkdir -p "$ROOT/inbox" "$ROOT/outbox"
+chmod 700 "$ROOT/inbox" "$ROOT/outbox"
+
+cordn \
+  --state-file "$ROOT/session.json" \
+  --daemon \
+  --group-alias office \
+  --inbox-dir "$ROOT/inbox" \
+  --outbox-dir "$ROOT/outbox"
+```
+
+The daemon is the sole MLS-state writer. Do not run another `cordn` process against the same snapshot while it is active. Send through the outbox instead, or gracefully stop the daemon before running a one-shot command.
+
+Use a service manager for restart policy. `SIGINT` and `SIGTERM` trigger final persistence and lock release.
+
+## Agent loop
+
+1. Atomically claim an inbox `.json` file by renaming it to a non-`.json` name.
+2. Validate its fields and authorize `groupAlias` and `sender`.
+3. Deduplicate by `groupAlias + cursor + id`.
+4. Produce a text response.
+5. Write the outbox payload to a temporary file in the outbox directory.
+6. Flush it and atomically rename it to a unique `.json` filename.
+7. Persist the consumer's deduplication record before deleting its claimed inbox file.
+
+Inbox and outbox delivery are at-least-once. A crash can produce duplicate work or duplicate messages; consumers must be idempotent.
+
+See `cordn docs queues` for exact schemas and shell examples.
+
+## Trust boundary
+
+Cordn decrypts messages before placing plaintext in the inbox. Sending that plaintext to an AI provider changes the privacy boundary: the provider can see it. Use an explicit bot identity, disclose the provider to group members, authorize senders, limit input size and rate, and disable agent tools unless separately sandboxed and approved.

--- a/packages/cli/docs/AGENT.md
+++ b/packages/cli/docs/AGENT.md
@@ -8,6 +8,7 @@ Use the CLI directly for bounded operations and its filesystem queues for a cont
 cordn --version
 cordn --help
 cordn docs
+cordn docs commands
 cordn docs queues
 ```
 

--- a/packages/cli/docs/COMMANDS.md
+++ b/packages/cli/docs/COMMANDS.md
@@ -1,0 +1,80 @@
+# Command reference
+
+Run one command and persist its result:
+
+```sh
+cordn --state-file <path> --command "<command>"
+```
+
+Or start the interactive REPL:
+
+```sh
+cordn --state-file <path>
+```
+
+## REPL commands
+
+```text
+help
+status
+whoami    (prints the private identity key)
+gen-kp [alias] [--coordinator <pubkey>] [--last-resort] [--local-only]
+publish-kp <alias> [--coordinator <pubkey>]
+key-packages | kps
+delete-kp <aliasOrKeyPackageRef> [--local-only] [--coordinator <pubkey>]
+available-kps [--coordinator <pubkey>]
+create-group <alias> [keyPackageAlias] [--coordinator <pubkey>] [--name <value>] [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]... [--watch]
+update-group-metadata <groupAlias> --name <value> [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]...
+set-metadata <groupAlias> --name <value> [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]...
+groups
+group-info [groupAlias]
+group <groupAlias> [--watch]
+use <groupAlias> [--watch]
+leave    (clear selection; does not change group membership)
+unwatch <groupAlias>
+add-member <groupAlias> <stablePubkeyOrKeyPackageRef>
+remove-member <groupAlias> <stablePubkey>
+fetch-welcomes [--coordinator <pubkey>]
+welcomes
+accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--coordinator <pubkey>] [--watch]
+fetch-join-requests [groupAlias]
+request-join <gid> [keyPackageAlias] [--coordinator <pubkey>]
+send <message...>    (uses selected group)
+send-to <groupAlias> <message...>
+send-media <filePath> [caption...]   (uses selected group; requires --media-dir)
+save-media [groupAlias] <cursor> [destDir]   (decrypts media to destDir, default .)
+sync [groupAlias]
+sync-all
+watch-all
+messages [groupAlias]
+issues [groupAlias]
+exit | quit
+```
+
+`groupAlias` is optional where shown only when a group is selected in the interactive REPL. One-shot commands do not retain selection; use explicit aliases and `send-to`.
+
+## KeyPackages
+
+`gen-kp` publishes immediately unless `--local-only` is supplied. Publish local-only material later with:
+
+```text
+publish-kp <alias> [--coordinator <pubkey>]
+```
+
+Regular KeyPackages support one invitation. `--last-resort` creates reusable invitation material.
+
+## Groups and watches
+
+`group` and `use` are aliases. `leave` only clears the local REPL selection; it does not remove the client from the MLS group. `--watch` performs catch-up before starting live delivery.
+
+`group-info` prints the protocol group ID required by `request-join`.
+
+## Startup commands
+
+These run before session or network initialization and are not REPL commands:
+
+```sh
+cordn --help
+cordn --version
+cordn docs [quickstart|commands|agent|daemon|queues|security]
+```

--- a/packages/cli/docs/DAEMON.md
+++ b/packages/cli/docs/DAEMON.md
@@ -1,0 +1,73 @@
+# Daemon mode
+
+The daemon is a foreground, long-running Cordn client. A service manager, container runtime, or terminal multiplexer is responsible for supervision.
+
+## Start
+
+```sh
+ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/cordn/agent"
+mkdir -p "$ROOT/inbox" "$ROOT/outbox"
+chmod 700 "$ROOT" "$ROOT/inbox" "$ROOT/outbox"
+
+cordn \
+  --state-file "$ROOT/session.json" \
+  --daemon \
+  --group-alias office \
+  --inbox-dir "$ROOT/inbox" \
+  --outbox-dir "$ROOT/outbox"
+```
+
+`--state-file` is required. Inbox and outbox directories must be distinct, and state/key JSON files cannot be placed inside either queue.
+
+## Cycle
+
+Approximately every five seconds the daemon:
+
+1. fetches pending Welcomes from the default coordinator
+2. accepts records matching locally held KeyPackage material
+3. persists each accepted group state
+4. starts or repairs watches for every active group
+5. processes outbox jobs in lexical filename order
+
+Group watches first perform bounded catch-up and then subscribe to live delivery. Once connected, inbound messages do not wait for the five-second polling interval.
+
+A regular KeyPackage is consumed by its first accepted invitation. A last-resort KeyPackage remains eligible for later invitations.
+
+`--group-alias` is both the base alias for newly accepted groups and the default group for outbox jobs that omit `groupAlias`. Additional groups receive numeric suffixes such as `office-2`. A newer re-invite to an existing protocol group retains its existing alias.
+
+## State ownership
+
+The daemon exclusively locks:
+
+```text
+<state-file>.lock
+```
+
+A second process using the snapshot fails rather than risking an MLS-state fork. If a process crashes, the next startup removes the lock only when its recorded PID is no longer running.
+
+All inbox and snapshot writes are serialized. An inbound inbox file becomes durable before the corresponding cursor is persisted, preventing permanent notification loss. Duplicate inbox records remain possible after a crash.
+
+## Shutdown
+
+Send `SIGINT` or `SIGTERM` for graceful shutdown. The daemon:
+
+1. leaves the polling loop
+2. disconnects live watches
+3. waits for queued inbox/state writes
+4. persists a final encrypted snapshot
+5. removes the state lock
+
+Shutdown can take roughly one polling interval. Use `SIGKILL` only when graceful shutdown cannot complete; queued `.processing` files and stale state locks are recovered on restart.
+
+## Failures
+
+- Welcome-fetch errors are logged; existing watches and outbox work continue.
+- One malformed or unprocessable Welcome does not stop other Welcomes.
+- Errored watches are retried in later cycles.
+- Invalid outbox JSON is quarantined as `.json.invalid`.
+- Send failures return the job to `.json` and retry it later.
+- A durability failure stops the daemon with nonzero status rather than advancing volatile MLS state.
+
+A valid job that fails permanently, such as one naming an unknown group, remains at the front of the ordered outbox and can delay later jobs. Operators should monitor daemon stderr and `.invalid`/`.processing` files.
+
+See `cordn docs queues` for the mailbox contract and `cordn docs security` for deployment guidance.

--- a/packages/cli/docs/QUEUES.md
+++ b/packages/cli/docs/QUEUES.md
@@ -1,0 +1,147 @@
+# Filesystem queue contract
+
+The queues provide local inter-process communication while the daemon exclusively owns MLS state.
+
+Use dedicated inbox and outbox directories on the same host. Producers must create temporary and final files in the same directory so rename is atomic.
+
+## Outbox: application to Cordn
+
+The daemon processes files ending in `.json` in lexical filename order.
+
+### Payload
+
+```json
+{
+  "groupAlias": "office",
+  "message": "hello"
+}
+```
+
+- `message` is required, must be a nonempty string, and is sent without trimming.
+- `groupAlias` must be a string when present.
+- `groupAlias` may be omitted when daemon startup supplied `--group-alias`.
+- Additional fields are currently ignored.
+
+### Atomic producer
+
+```sh
+OUTBOX=/path/to/outbox
+id="$(date +%s%N)"
+temporary="$OUTBOX/$id.tmp"
+final="$OUTBOX/$id.json"
+
+jq -cn \
+  --arg groupAlias office \
+  --arg message 'hello' \
+  '{groupAlias: $groupAlias, message: $message}' > "$temporary"
+chmod 600 "$temporary"
+sync -f "$temporary"
+mv "$temporary" "$final"
+```
+
+Never stream content directly into a `.json` filename. The rename into `.json` commits the job.
+
+Timestamp-prefixed names are a convenient ordering convention, but every producer must ensure filenames are unique.
+
+### Daemon lifecycle
+
+```text
+job.json
+  → job.json.processing
+  → send to coordinator
+  → persist updated MLS state
+  → delete job.json.processing
+```
+
+Malformed JSON or invalid fields produce:
+
+```text
+job.json.invalid
+```
+
+The daemon continues with later jobs after quarantining malformed input.
+
+A send or persistence failure returns `.processing` to `.json` and stops that processing pass. A `.json.processing` file left by a crash is adopted on the next pass.
+
+The daemon logs successful acceptance as:
+
+```text
+outbox sent <filename> cursor=<cursor>
+```
+
+File deletion means the coordinator accepted the message and the updated local MLS state was persisted. It does not prove every peer has already received it.
+
+## Inbox: Cordn to application
+
+The daemon writes one atomic `.json` file for every newly decrypted inbound message.
+
+### Payload
+
+```json
+{
+  "groupAlias": "office",
+  "cursor": 12,
+  "createdAt": 1730000000000,
+  "sender": "64-character-stable-public-key",
+  "id": "nostr-event-id",
+  "content": "hello"
+}
+```
+
+Current inbox records are text-oriented and omit event tags and media metadata. Outbound self-echoes are reconciled internally and are not emitted as inbound jobs.
+
+Filenames have this shape:
+
+```text
+0000000000000012-<uuid>.json
+```
+
+The padded cursor provides useful lexical order within a group. Cursors are independent per group; the directory is not one global cross-group timeline.
+
+The daemon writes and flushes `<name>.json.tmp`, atomically renames it to `<name>.json`, syncs the inbox directory, and then persists the updated session cursor.
+
+### Consumer
+
+Atomically claim each file before processing:
+
+```sh
+INBOX=/path/to/inbox
+
+for file in "$INBOX"/*.json; do
+  [ -e "$file" ] || continue
+  claimed="$file.claimed.$$"
+  mv "$file" "$claimed" || continue
+
+  # Validate and authorize the JSON.
+  # Persist deduplication and application effects.
+
+  rm "$claimed"
+done
+```
+
+The consumer owns recovery for its `.claimed.*` files. The Cordn daemon never removes inbox records.
+
+Deduplicate with the tuple:
+
+```text
+groupAlias + cursor + id
+```
+
+Authorize both the local group and stable sender before passing plaintext to an automation or model.
+
+## Delivery guarantee
+
+Both directions are at-least-once.
+
+Outbox duplication can occur if the coordinator accepts a message but the process crashes before deleting its job. Inbox duplication can occur if the inbox file becomes durable but the process crashes before persisting its cursor.
+
+Exactly-once application behavior requires an application-level idempotency key and durable deduplication journal.
+
+## Permissions and placement
+
+- Create queue directories with mode `0700`.
+- Create files with mode `0600`.
+- Keep inbox and outbox separate.
+- Never place the encrypted state or state-key file inside a queue.
+- Do not let untrusted users write jobs into the outbox.
+- Do not expose decrypted inbox files beyond the intended consumer.

--- a/packages/cli/docs/QUICKSTART.md
+++ b/packages/cli/docs/QUICKSTART.md
@@ -94,6 +94,7 @@ A newer re-invite refreshes the existing protocol group and retains its local al
 
 ## Next
 
+- `cordn docs commands`
 - `cordn docs agent`
 - `cordn docs daemon`
 - `cordn docs queues`

--- a/packages/cli/docs/QUICKSTART.md
+++ b/packages/cli/docs/QUICKSTART.md
@@ -1,0 +1,100 @@
+# Quickstart
+
+## Install
+
+```sh
+npm install --global @cordn/cli
+cordn --version
+```
+
+Node.js 20.12 or newer is required.
+
+## Create a persistent client
+
+```sh
+STATE="${XDG_STATE_HOME:-$HOME/.local/state}/cordn/session.json"
+cordn --state-file "$STATE" --command status
+```
+
+On first use, Cordn generates a client identity and creates:
+
+- `$STATE` — AES-256-GCM encrypted client snapshot
+- `$STATE.key` — the 32-byte snapshot encryption key, encoded as hex
+
+The bundled coordinator and relay defaults require no initial network flags. Override them when needed:
+
+```sh
+cordn \
+  --server-pubkey <64-character-hex-public-key> \
+  --relay wss://relay.example \
+  --state-file "$STATE" \
+  --command status
+```
+
+The selected coordinator and relays are saved in the snapshot, so subsequent commands only need `--state-file`.
+
+## Inspect the public identity
+
+`status` prints the stable public key without exposing the private key:
+
+```sh
+cordn --state-file "$STATE" --command status
+```
+
+`whoami` also prints the private identity key; do not run it in shared logs or untrusted agent contexts.
+
+## Publish a KeyPackage
+
+A regular KeyPackage is consumed by one invitation:
+
+```sh
+cordn --state-file "$STATE" --command "gen-kp main"
+```
+
+A last-resort KeyPackage can receive multiple invitations:
+
+```sh
+cordn --state-file "$STATE" --command "gen-kp reusable --last-resort"
+```
+
+## Create and use a group
+
+```sh
+cordn --state-file "$STATE" --command "create-group office"
+cordn --state-file "$STATE" --command "groups"
+cordn --state-file "$STATE" --command "send-to office hello"
+cordn --state-file "$STATE" --command "messages office"
+```
+
+For an interactive session:
+
+```sh
+cordn --state-file "$STATE"
+```
+
+Inside the REPL:
+
+```text
+use office --watch
+hello from the REPL
+messages office
+exit
+```
+
+## Accept an invitation
+
+```sh
+cordn --state-file "$STATE" --command "fetch-welcomes"
+cordn --state-file "$STATE" --command "welcomes"
+cordn --state-file "$STATE" \
+  --command "accept-welcome <coordinator>:<kp_ref>:<at> office"
+```
+
+A newer re-invite refreshes the existing protocol group and retains its local alias and history.
+
+## Next
+
+- `cordn docs agent`
+- `cordn docs daemon`
+- `cordn docs queues`
+- `cordn docs security`

--- a/packages/cli/docs/README.md
+++ b/packages/cli/docs/README.md
@@ -15,6 +15,7 @@ Override them with `--server-pubkey` and one or more `--relay` options. A persis
 
 ```sh
 cordn docs quickstart  # installation and first group
+cordn docs commands    # complete REPL and one-shot command reference
 cordn docs agent       # safe non-interactive and agent usage
 cordn docs daemon      # daemon lifecycle and recovery
 cordn docs queues      # inbox/outbox schemas and atomic file protocol

--- a/packages/cli/docs/README.md
+++ b/packages/cli/docs/README.md
@@ -1,0 +1,24 @@
+# Cordn CLI documentation
+
+`cordn` is a persistent MLS client for interactive use, scripts, and local agent integrations.
+
+## Bundled defaults
+
+A fresh client connects to:
+
+- coordinator: `92753cbe63e943d0c4a0c61d745437892af6e98f179ce04a7a863aad4e00b1a5`
+- relays: `wss://relay.contextvm.org`, `wss://relay2.contextvm.org`, `wss://relay.primal.net`
+
+Override them with `--server-pubkey` and one or more `--relay` options. A persistent state snapshot remembers the coordinator and relays used to create it.
+
+## Topics
+
+```sh
+cordn docs quickstart  # installation and first group
+cordn docs agent       # safe non-interactive and agent usage
+cordn docs daemon      # daemon lifecycle and recovery
+cordn docs queues      # inbox/outbox schemas and atomic file protocol
+cordn docs security    # identity, state, permissions, and trust boundaries
+```
+
+All documentation is bundled with the installed CLI and matches its version. Run `cordn --help` for startup options and start the interactive REPL with `cordn --state-file <path>` for its command list.

--- a/packages/cli/docs/SECURITY.md
+++ b/packages/cli/docs/SECURITY.md
@@ -1,0 +1,64 @@
+# Security
+
+## Hosted default
+
+Without explicit configuration, the CLI uses:
+
+```text
+coordinator: 92753cbe63e943d0c4a0c61d745437892af6e98f179ce04a7a863aad4e00b1a5
+relays:
+  wss://relay.contextvm.org
+  wss://relay2.contextvm.org
+  wss://relay.primal.net
+```
+
+The coordinator and relays are routing infrastructure; MLS message content remains encrypted in transit. Override these values with `--server-pubkey` and `--relay` when using another deployment. Explicit options take precedence over restored state, restored state over environment configuration, and environment configuration over bundled defaults.
+
+The CLI retains `CORDN_SERVER_PRIVATE_KEY` only as a local-development fallback for deriving a coordinator public key. Never distribute a coordinator private key to clients.
+
+## Client identity and snapshot
+
+The encrypted snapshot contains:
+
+- the client private identity key
+- private KeyPackage material
+- MLS group states and epoch secrets
+- message history and cursors
+- pending protocol operations and acknowledgements
+
+The companion state-key file decrypts all of it. Protect both files with mode `0600`, keep their parent directory private, and back them up together through an encrypted channel.
+
+Losing the snapshot loses MLS continuity and history. Losing the state key makes the snapshot unrecoverable. Copying both gives the recipient control of the client identity and group membership.
+
+The CLI writes snapshots with AES-256-GCM through a flushed temporary file and atomic rename. It exclusively locks a snapshot while in use; never bypass or manually remove a lock belonging to a running process.
+
+## Command output
+
+`status` prints only the stable public key and object counts.
+
+`whoami` prints the private identity key as well as the public key. Use it only in a private terminal when explicit private-key export is intended. Do not invoke it from general-purpose agents, logs, CI, or support transcripts.
+
+KeyPackage references, stable public keys, coordinator keys, group cursors, and event IDs are public identifiers. Snapshot keys and client/coordinator private keys are secrets.
+
+## Filesystem queues
+
+The inbox contains decrypted plaintext. The outbox accepts plaintext that the daemon will send as the client identity.
+
+Restrict queue ownership and permissions. Validate schemas, authorize group aliases and stable senders, cap input size and rate, and persist deduplication before deleting claimed input.
+
+The filesystem boundary protects the MLS ratchet by leaving the daemon as its only writer. It does not sandbox another process running as the same operating-system user. For stronger isolation, run the daemon and automation as separate users and grant only the required queue access.
+
+## AI integrations
+
+Sending decrypted group content to a model provider extends the privacy boundary beyond Cordn. Use an explicit bot identity and disclose the provider and retention policy to group members.
+
+Disable model tools by default. If tools are required, sandbox them and separately authorize capabilities; group messages are untrusted input and may contain prompt-injection attempts. Prevent bot-to-bot response loops and apply token/rate budgets.
+
+## Operational guidance
+
+- Pin the installed CLI version for long-running daemons.
+- Run daemons under a service manager with controlled restart policy.
+- Monitor stderr, quarantined jobs, queue depth, and state-write failures.
+- Gracefully stop the daemon before backups or upgrades.
+- Test snapshot restoration before depending on a backup.
+- Remove abandoned bot members from groups after destroying their local identity state.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,48 @@
 {
   "name": "@cordn/cli",
   "version": "0.5.3",
-  "private": true,
+  "description": "Persistent MLS client for Cordn: interactive commands, encrypted state, and durable agent inbox/outbox queues.",
   "type": "module",
-  "main": "./src/main.ts",
+  "license": "MIT",
+  "bin": {
+    "cordn": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "docs",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20.12"
+  },
+  "keywords": [
+    "cordn",
+    "mls",
+    "nostr",
+    "contextvm",
+    "messaging",
+    "cli",
+    "agent"
+  ],
+  "homepage": "https://github.com/Cordn-msg/cordn/tree/master/packages/cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cordn-msg/cordn.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/Cordn-msg/cordn/issues"
+  },
+  "scripts": {
+    "build": "rm -rf dist && esbuild ./src/main.ts --bundle --platform=node --target=node20 --format=esm --packages=external --external:@cordn/core --outfile=./dist/cli.js --banner:js=\"#!/usr/bin/env node\" && chmod +x ./dist/cli.js",
+    "pack:check": "node ./scripts/pack-smoke.mjs",
+    "prepack": "pnpm run build"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@contextvm/mcp-sdk": "^1.30",
     "@contextvm/sdk": "^0.13.10",
@@ -17,6 +56,7 @@
   "devDependencies": {
     "@cordn/server": "workspace:*",
     "@cordn/test-utils": "workspace:*",
+    "esbuild": "^0.27.7",
     "vitest": "^4.1.5"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cordn/cli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Persistent MLS client for Cordn: interactive commands, encrypted state, and durable agent inbox/outbox queues.",
   "type": "module",
   "license": "MIT",

--- a/packages/cli/scripts/pack-smoke.mjs
+++ b/packages/cli/scripts/pack-smoke.mjs
@@ -33,6 +33,7 @@ try {
   for (const required of [
     "package/dist/cli.js",
     "package/docs/AGENT.md",
+    "package/docs/COMMANDS.md",
     "package/README.md",
     "package/LICENSE",
   ]) {
@@ -74,6 +75,12 @@ try {
   });
   if (!agentDocs.startsWith("# Agent usage")) {
     throw new Error("installed CLI could not read bundled agent docs");
+  }
+  const { stdout: commandDocs } = await exec(executable, ["docs", "commands"], {
+    cwd: installDir,
+  });
+  if (!commandDocs.includes("publish-kp <alias>")) {
+    throw new Error("installed CLI command reference is incomplete");
   }
 
   const stateFile = join(installDir, "state", "session.json");

--- a/packages/cli/scripts/pack-smoke.mjs
+++ b/packages/cli/scripts/pack-smoke.mjs
@@ -1,0 +1,92 @@
+import { execFile } from "node:child_process";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const temporaryDir = await mkdtemp(join(tmpdir(), "cordn-cli-pack-"));
+
+try {
+  await exec("pnpm", ["pack", "--pack-destination", temporaryDir], {
+    cwd: packageDir,
+  });
+  const archiveName = (await readdir(temporaryDir)).find((name) =>
+    name.endsWith(".tgz"),
+  );
+  if (!archiveName) throw new Error("pnpm pack did not produce an archive");
+  const archive = join(temporaryDir, archiveName);
+
+  const { stdout: packedFiles } = await exec("tar", ["-tzf", archive]);
+  if (/package\/src\//.test(packedFiles) || /\.test\.ts$/m.test(packedFiles)) {
+    throw new Error("published archive contains source tests");
+  }
+  for (const required of [
+    "package/dist/cli.js",
+    "package/docs/AGENT.md",
+    "package/README.md",
+    "package/LICENSE",
+  ]) {
+    if (!packedFiles.split("\n").includes(required)) {
+      throw new Error(`published archive is missing ${required}`);
+    }
+  }
+
+  const installDir = join(temporaryDir, "install");
+  await mkdir(installDir);
+  await writeFile(
+    join(installDir, "package.json"),
+    '{"name":"cordn-cli-pack-smoke","private":true}\n',
+  );
+  await exec(
+    "npm",
+    ["install", "--ignore-scripts", "--no-audit", "--no-fund", archive],
+    { cwd: installDir },
+  );
+
+  const manifest = JSON.parse(
+    await readFile(join(packageDir, "package.json"), "utf8"),
+  );
+  const executable = join(installDir, "node_modules", ".bin", "cordn");
+  const { stdout: version } = await exec(executable, ["--version"], {
+    cwd: installDir,
+  });
+  if (version.trim() !== manifest.version) {
+    throw new Error(`unexpected version output: ${version.trim()}`);
+  }
+  const { stdout: help } = await exec(executable, ["--help"], {
+    cwd: installDir,
+  });
+  if (!help.includes("docs [topic]")) {
+    throw new Error("installed help does not advertise bundled docs");
+  }
+  const { stdout: agentDocs } = await exec(executable, ["docs", "agent"], {
+    cwd: installDir,
+  });
+  if (!agentDocs.startsWith("# Agent usage")) {
+    throw new Error("installed CLI could not read bundled agent docs");
+  }
+
+  const stateFile = join(installDir, "state", "session.json");
+  const { stdout: status } = await exec(
+    executable,
+    ["--state-file", stateFile, "--command", "status"],
+    { cwd: installDir },
+  );
+  if (!status.includes("groupCount: 0")) {
+    throw new Error("installed CLI could not bootstrap with hosted defaults");
+  }
+
+  console.log(`pack smoke passed: ${archiveName}`);
+} finally {
+  await rm(temporaryDir, { recursive: true, force: true });
+}

--- a/packages/cli/src/coordinatorClient.ts
+++ b/packages/cli/src/coordinatorClient.ts
@@ -48,6 +48,8 @@ import {
   removeKeyPackagesOutputSchema,
 } from "@cordn/core";
 
+import { DEFAULT_RELAY_URLS } from "./defaults.ts";
+
 export type coordinatorClient = {
   PublishKeyPackage: (
     input: PublishKeyPackageInput,
@@ -87,8 +89,7 @@ export type coordinatorClient = {
 };
 
 export class cordnClient implements coordinatorClient {
-  static readonly DEFAULT_RELAYS = ["ws://localhost:10547"];
-  // static readonly DEFAULT_RELAYS = ["wss://relay.contextvm.org"];
+  static readonly DEFAULT_RELAYS = [...DEFAULT_RELAY_URLS];
   private readonly stableClient: Client;
   private readonly stableTransport: NostrClientTransport;
   private readonly stableConnected: Promise<void>;

--- a/packages/cli/src/coordinatorRegistry.ts
+++ b/packages/cli/src/coordinatorRegistry.ts
@@ -76,6 +76,14 @@ export class CoordinatorClientRegistry {
     return this.defaultCoordinatorPubkey;
   }
 
+  get defaultCoordinatorTarget(): CoordinatorTarget {
+    const target = this.getTarget(this.defaultCoordinatorPubkey);
+    return {
+      serverPubkey: target.serverPubkey,
+      ...(target.relays ? { relays: [...target.relays] } : {}),
+    };
+  }
+
   register(target: CoordinatorTarget): string {
     const key = target.serverPubkey;
     const existing = this.targets.get(key);

--- a/packages/cli/src/defaults.test.ts
+++ b/packages/cli/src/defaults.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+
+import { DEFAULT_COORDINATOR_PUBKEY, DEFAULT_RELAY_URLS } from "./defaults.ts";
+
+describe("CLI hosted defaults", () => {
+  test("pins the public coordinator and relay set", () => {
+    expect(DEFAULT_COORDINATOR_PUBKEY).toBe(
+      "92753cbe63e943d0c4a0c61d745437892af6e98f179ce04a7a863aad4e00b1a5",
+    );
+    expect(DEFAULT_COORDINATOR_PUBKEY).toMatch(/^[0-9a-f]{64}$/);
+    expect(DEFAULT_RELAY_URLS).toEqual([
+      "wss://relay.contextvm.org",
+      "wss://relay2.contextvm.org",
+      "wss://relay.primal.net",
+    ]);
+  });
+});

--- a/packages/cli/src/defaults.ts
+++ b/packages/cli/src/defaults.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_COORDINATOR_PUBKEY =
+  "92753cbe63e943d0c4a0c61d745437892af6e98f179ce04a7a863aad4e00b1a5";
+
+export const DEFAULT_RELAY_URLS = [
+  "wss://relay.contextvm.org",
+  "wss://relay2.contextvm.org",
+  "wss://relay.primal.net",
+] as const;

--- a/packages/cli/src/docs.test.ts
+++ b/packages/cli/src/docs.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+
+import { CLI_DOC_TOPICS, readCliDoc } from "./docs.ts";
+
+describe("bundled CLI docs", () => {
+  test("loads every advertised topic", async () => {
+    const docs = await Promise.all(
+      CLI_DOC_TOPICS.map((topic) => readCliDoc(topic)),
+    );
+
+    expect(docs).toHaveLength(5);
+    expect(docs.every((content) => content.startsWith("# "))).toBe(true);
+  });
+
+  test("loads the index without a topic", async () => {
+    await expect(readCliDoc()).resolves.toContain("cordn docs quickstart");
+  });
+
+  test("rejects unknown topics with the available list", async () => {
+    await expect(readCliDoc("missing")).rejects.toThrow(
+      "available topics: quickstart, agent, daemon, queues, security",
+    );
+  });
+});

--- a/packages/cli/src/docs.test.ts
+++ b/packages/cli/src/docs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { CLI_DOC_TOPICS, readCliDoc } from "./docs.ts";
+import { REPL_COMMAND_HELP } from "./replFormat.ts";
 
 describe("bundled CLI docs", () => {
   test("loads every advertised topic", async () => {
@@ -8,7 +9,7 @@ describe("bundled CLI docs", () => {
       CLI_DOC_TOPICS.map((topic) => readCliDoc(topic)),
     );
 
-    expect(docs).toHaveLength(5);
+    expect(docs).toHaveLength(6);
     expect(docs.every((content) => content.startsWith("# "))).toBe(true);
   });
 
@@ -16,9 +17,17 @@ describe("bundled CLI docs", () => {
     await expect(readCliDoc()).resolves.toContain("cordn docs quickstart");
   });
 
+  test("documents every interactive command", async () => {
+    const commands = await readCliDoc("commands");
+
+    for (const { usage } of REPL_COMMAND_HELP) {
+      expect(commands).toContain(usage);
+    }
+  });
+
   test("rejects unknown topics with the available list", async () => {
     await expect(readCliDoc("missing")).rejects.toThrow(
-      "available topics: quickstart, agent, daemon, queues, security",
+      "available topics: quickstart, commands, agent, daemon, queues, security",
     );
   });
 });

--- a/packages/cli/src/docs.ts
+++ b/packages/cli/src/docs.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 
 const DOC_FILES = {
   quickstart: "QUICKSTART.md",
+  commands: "COMMANDS.md",
   agent: "AGENT.md",
   daemon: "DAEMON.md",
   queues: "QUEUES.md",

--- a/packages/cli/src/docs.ts
+++ b/packages/cli/src/docs.ts
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+
+const DOC_FILES = {
+  quickstart: "QUICKSTART.md",
+  agent: "AGENT.md",
+  daemon: "DAEMON.md",
+  queues: "QUEUES.md",
+  security: "SECURITY.md",
+} as const;
+
+export const CLI_DOC_TOPICS = Object.keys(DOC_FILES);
+
+export async function readCliDoc(topic?: string): Promise<string> {
+  const normalized = topic?.trim().toLowerCase();
+  if (!normalized || normalized === "help" || normalized === "index") {
+    return readFile(new URL("../docs/README.md", import.meta.url), "utf8");
+  }
+
+  const file = DOC_FILES[normalized as keyof typeof DOC_FILES];
+  if (!file) {
+    throw new Error(
+      `unknown docs topic: ${topic}; available topics: ${CLI_DOC_TOPICS.join(", ")}`,
+    );
+  }
+
+  return readFile(new URL(`../docs/${file}`, import.meta.url), "utf8");
+}

--- a/packages/cli/src/groupSync.test.ts
+++ b/packages/cli/src/groupSync.test.ts
@@ -125,6 +125,45 @@ describe("ingestGroupMessages", () => {
     expect(group.lastCursor).toBe(7);
   });
 
+  test("applies a pending Commit restored before local state adoption", async () => {
+    const group = createGroupState();
+    const newState = {
+      groupActiveState: { kind: "active" },
+    } as unknown as GroupSessionState["state"];
+    const pending = {
+      kind: "update-group-metadata" as const,
+      groupAlias: "demo",
+      groupId: "gid",
+      commitMessageBase64: "pending-commit",
+      localStateApplied: false,
+      status: "pending" as const,
+    };
+    processMessageBase64.mockResolvedValueOnce({
+      kind: "newState",
+      newState,
+    });
+
+    const result = await ingestGroupMessages({
+      group,
+      messages: [
+        {
+          cursor: 8,
+          createdAt: 80,
+          opaqueMessageBase64: "pending-commit",
+        },
+      ],
+      getPendingEpochOperation: () => pending,
+      localStablePubkey: "alice",
+    });
+
+    expect(processMessageBase64).toHaveBeenCalledOnce();
+    expect(group.state).toBe(newState);
+    expect(pending.localStateApplied).toBe(true);
+    expect(result.appliedPendingCommitMessages).toEqual(
+      new Set(["pending-commit"]),
+    );
+  });
+
   test("records stale-epoch issues and advances fetch progress", async () => {
     const group = createGroupState();
 

--- a/packages/cli/src/groupSync.ts
+++ b/packages/cli/src/groupSync.ts
@@ -107,7 +107,11 @@ export async function ingestGroupMessages(params: {
     );
     const isPendingOperationMessage = pendingOperation !== undefined;
 
-    if (isPendingOperationMessage) {
+    // Normal pending ops already adopted the post-Commit state immediately
+    // after posting, so their self-echo is confirmation only. A snapshot taken
+    // while posting records `localStateApplied: false`; that echo must actually
+    // apply the Commit to recover the state after restart.
+    if (pendingOperation && pendingOperation.localStateApplied !== false) {
       group.fetchCursor = message.cursor;
       group.lastCursor = Math.max(group.lastCursor, message.cursor);
       appliedPendingCommitMessages.add(message.opaqueMessageBase64);
@@ -160,6 +164,7 @@ export async function ingestGroupMessages(params: {
           pendingOperation !== undefined &&
           (isRemovedMemberCommitIssue(detail) || isFormerEpochIssue(detail))
         ) {
+          pendingOperation.localStateApplied = true;
           appliedPendingCommitMessages.add(message.opaqueMessageBase64);
         } else if (
           isRemovedMemberCommitIssue(detail) &&
@@ -272,15 +277,15 @@ export async function ingestGroupMessages(params: {
     group.fetchCursor = message.cursor;
     group.lastCursor = Math.max(group.lastCursor, message.cursor);
 
-    if (isPendingOperationMessage) {
-      appliedPendingCommitMessages.add(message.opaqueMessageBase64);
-    }
-
     if (processed.kind !== "newState") {
       continue;
     }
 
     group.state = processed.newState;
+    if (pendingOperation) {
+      pendingOperation.localStateApplied = true;
+      appliedPendingCommitMessages.add(message.opaqueMessageBase64);
+    }
     group.metadata = getCordnGroupMetadataExtension(processed.newState);
 
     if (

--- a/packages/cli/src/inbox.test.ts
+++ b/packages/cli/src/inbox.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { enqueueInboundMessages } from "./inbox.ts";
+
+const directories: string[] = [];
+afterEach(async () =>
+  Promise.all(
+    directories.splice(0).map((path) => rm(path, { recursive: true })),
+  ),
+);
+
+describe("inbound message queue", () => {
+  test("atomically queues only inbound group messages", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-inbox-"));
+    directories.push(directory);
+    const base = {
+      createdAt: 123,
+      sender: "a".repeat(64),
+      id: "b".repeat(64),
+      kind: 9,
+      tags: [],
+      content: "hello",
+    };
+
+    await enqueueInboundMessages(directory, "office", [
+      { ...base, cursor: 7, direction: "inbound" },
+      { ...base, cursor: 8, direction: "outbound" },
+    ]);
+
+    const files = await readdir(directory);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^0{15}7-.+\.json$/);
+    expect(
+      JSON.parse(await readFile(join(directory, files[0]!), "utf8")),
+    ).toMatchObject({
+      groupAlias: "office",
+      cursor: 7,
+      sender: "a".repeat(64),
+      content: "hello",
+    });
+  });
+});

--- a/packages/cli/src/inbox.ts
+++ b/packages/cli/src/inbox.ts
@@ -1,0 +1,33 @@
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type { StoredMessage } from "./sessionState.ts";
+
+export async function enqueueInboundMessages(
+  inboxDir: string,
+  groupAlias: string,
+  messages: StoredMessage[],
+): Promise<void> {
+  await mkdir(inboxDir, { recursive: true, mode: 0o700 });
+  for (const message of messages.filter(
+    (item) => item.direction === "inbound",
+  )) {
+    const name = `${String(message.cursor).padStart(16, "0")}-${randomUUID()}.json`;
+    const finalPath = join(inboxDir, name);
+    const temporaryPath = `${finalPath}.tmp`;
+    await writeFile(
+      temporaryPath,
+      `${JSON.stringify({
+        groupAlias,
+        cursor: message.cursor,
+        createdAt: message.createdAt,
+        sender: message.sender,
+        id: message.id,
+        content: message.content,
+      })}\n`,
+      { mode: 0o600 },
+    );
+    await rename(temporaryPath, finalPath);
+  }
+}

--- a/packages/cli/src/inbox.ts
+++ b/packages/cli/src/inbox.ts
@@ -1,4 +1,4 @@
-import { mkdir, rename, writeFile } from "node:fs/promises";
+import { mkdir, open, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -10,6 +10,7 @@ export async function enqueueInboundMessages(
   messages: StoredMessage[],
 ): Promise<void> {
   await mkdir(inboxDir, { recursive: true, mode: 0o700 });
+  let wrote = false;
   for (const message of messages.filter(
     (item) => item.direction === "inbound",
   )) {
@@ -26,8 +27,17 @@ export async function enqueueInboundMessages(
         id: message.id,
         content: message.content,
       })}\n`,
-      { mode: 0o600 },
+      { mode: 0o600, flush: true },
     );
     await rename(temporaryPath, finalPath);
+    wrote = true;
+  }
+  if (wrote) {
+    const directory = await open(inboxDir, "r");
+    try {
+      await directory.sync();
+    } finally {
+      await directory.close();
+    }
   }
 }

--- a/packages/cli/src/localState.test.ts
+++ b/packages/cli/src/localState.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { loadEncryptedState, saveEncryptedState } from "./localState.ts";
+
+describe("encrypted local state", () => {
+  test("round-trips state without storing plaintext and protects the key", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-state-"));
+    const statePath = join(directory, "session.json");
+    const keyPath = join(directory, "session.key");
+    const value = { privateKey: "not-plaintext", cursor: 42 };
+
+    await saveEncryptedState(statePath, keyPath, value);
+
+    expect(await loadEncryptedState(statePath, keyPath)).toEqual(value);
+    expect(await readFile(statePath, "utf8")).not.toContain(value.privateKey);
+    expect((await stat(keyPath)).mode & 0o777).toBe(0o600);
+    expect((await stat(statePath)).mode & 0o777).toBe(0o600);
+  });
+
+  test("rejects tampered ciphertext", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-state-"));
+    const statePath = join(directory, "session.json");
+    const keyPath = join(directory, "session.key");
+    await saveEncryptedState(statePath, keyPath, { cursor: 1 });
+
+    const envelope = JSON.parse(await readFile(statePath, "utf8"));
+    envelope.ciphertext = `${envelope.ciphertext.slice(0, -2)}AA`;
+    await writeFile(statePath, JSON.stringify(envelope));
+
+    await expect(loadEncryptedState(statePath, keyPath)).rejects.toThrow();
+  });
+
+  test("supports concurrent atomic saves", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-state-"));
+    const statePath = join(directory, "session.json");
+    const keyPath = join(directory, "session.key");
+
+    await saveEncryptedState(statePath, keyPath, { cursor: -1 });
+    await Promise.all(
+      Array.from({ length: 10 }, (_, cursor) =>
+        saveEncryptedState(statePath, keyPath, { cursor }),
+      ),
+    );
+
+    const restored = await loadEncryptedState<{ cursor: number }>(
+      statePath,
+      keyPath,
+    );
+    expect(restored?.cursor).toBeGreaterThanOrEqual(0);
+    expect(restored?.cursor).toBeLessThan(10);
+  });
+});

--- a/packages/cli/src/localState.test.ts
+++ b/packages/cli/src/localState.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
-import { loadEncryptedState, saveEncryptedState } from "./localState.ts";
+import {
+  acquireStateLock,
+  loadEncryptedState,
+  saveEncryptedState,
+} from "./localState.ts";
 
 describe("encrypted local state", () => {
   test("round-trips state without storing plaintext and protects the key", async () => {
@@ -33,12 +37,24 @@ describe("encrypted local state", () => {
     await expect(loadEncryptedState(statePath, keyPath)).rejects.toThrow();
   });
 
-  test("supports concurrent atomic saves", async () => {
+  test("captures mutable input before yielding", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-state-"));
+    const statePath = join(directory, "session.json");
+    const keyPath = join(directory, "session.key");
+    const value = { cursor: 1 };
+
+    const saving = saveEncryptedState(statePath, keyPath, value);
+    value.cursor = 2;
+    await saving;
+
+    expect(await loadEncryptedState(statePath, keyPath)).toEqual({ cursor: 1 });
+  });
+
+  test("supports concurrent first saves with one atomic key", async () => {
     const directory = await mkdtemp(join(tmpdir(), "cordn-state-"));
     const statePath = join(directory, "session.json");
     const keyPath = join(directory, "session.key");
 
-    await saveEncryptedState(statePath, keyPath, { cursor: -1 });
     await Promise.all(
       Array.from({ length: 10 }, (_, cursor) =>
         saveEncryptedState(statePath, keyPath, { cursor }),
@@ -51,5 +67,19 @@ describe("encrypted local state", () => {
     );
     expect(restored?.cursor).toBeGreaterThanOrEqual(0);
     expect(restored?.cursor).toBeLessThan(10);
+  });
+
+  test("allows only one process writer per state file", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-state-"));
+    const statePath = join(directory, "session.json");
+    const release = await acquireStateLock(statePath);
+
+    await expect(acquireStateLock(statePath)).rejects.toThrow(
+      `state file is already in use by pid ${process.pid}`,
+    );
+    await release();
+
+    const releaseAgain = await acquireStateLock(statePath);
+    await releaseAgain();
   });
 });

--- a/packages/cli/src/localState.ts
+++ b/packages/cli/src/localState.ts
@@ -1,26 +1,50 @@
 import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
-import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { dirname } from "node:path";
 
-export interface EncryptedStateEnvelope {
+interface EncryptedStateEnvelope {
   version: 1;
   iv: string;
   tag: string;
   ciphertext: string;
 }
 
+async function readKey(keyPath: string): Promise<Buffer> {
+  const encoded = (await readFile(keyPath, "utf8")).trim();
+  if (!/^[0-9a-f]{64}$/i.test(encoded)) {
+    throw new Error("state key must be exactly 32 bytes encoded as hex");
+  }
+  return Buffer.from(encoded, "hex");
+}
+
 async function readOrCreateKey(keyPath: string): Promise<Buffer> {
   try {
-    const key = Buffer.from((await readFile(keyPath, "utf8")).trim(), "hex");
-    if (key.length !== 32) throw new Error("state key must be 32 bytes");
-    return key;
+    return await readKey(keyPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     await mkdir(dirname(keyPath), { recursive: true, mode: 0o700 });
     const key = randomBytes(32);
-    await writeFile(keyPath, `${key.toString("hex")}\n`, { mode: 0o600 });
-    await chmod(keyPath, 0o600);
-    return key;
+    try {
+      await writeFile(keyPath, `${key.toString("hex")}\n`, {
+        mode: 0o600,
+        flag: "wx",
+        flush: true,
+      });
+      await syncDirectory(dirname(keyPath));
+      return key;
+    } catch (writeError) {
+      if ((writeError as NodeJS.ErrnoException).code === "EEXIST") {
+        return readKey(keyPath);
+      }
+      throw writeError;
+    }
   }
 }
 
@@ -36,7 +60,12 @@ export async function loadEncryptedState<T>(
     throw error;
   }
   if (envelope.version !== 1) throw new Error("unsupported state version");
-  const key = await readOrCreateKey(keyPath);
+  const key = await readKey(keyPath).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`state key file not found: ${keyPath}`);
+    }
+    throw error;
+  });
   const decipher = createDecipheriv(
     "aes-256-gcm",
     key,
@@ -55,11 +84,14 @@ export async function saveEncryptedState(
   keyPath: string,
   value: unknown,
 ): Promise<void> {
+  // Capture mutable session state synchronously before the first await; watch
+  // ingestion can otherwise change live arrays while the key file is read.
+  const plaintext = JSON.stringify(value);
   const key = await readOrCreateKey(keyPath);
   const iv = randomBytes(12);
   const cipher = createCipheriv("aes-256-gcm", key, iv);
   const ciphertext = Buffer.concat([
-    cipher.update(JSON.stringify(value), "utf8"),
+    cipher.update(plaintext, "utf8"),
     cipher.final(),
   ]);
   const envelope: EncryptedStateEnvelope = {
@@ -72,7 +104,75 @@ export async function saveEncryptedState(
   // Multiple group events can request persistence concurrently. A shared
   // `.tmp` name lets one save rename another save's file out from under it.
   const temporary = `${statePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await writeFile(temporary, `${JSON.stringify(envelope)}\n`, { mode: 0o600 });
-  await chmod(temporary, 0o600);
+  await writeFile(temporary, `${JSON.stringify(envelope)}\n`, {
+    mode: 0o600,
+    flush: true,
+  });
   await rename(temporary, statePath);
+  await syncDirectory(dirname(statePath));
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const handle = await open(path, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Exclusive process lock: one MLS session writer per state file. */
+export async function acquireStateLock(
+  statePath: string,
+): Promise<() => Promise<void>> {
+  const lockPath = `${statePath}.lock`;
+  await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
+
+  for (;;) {
+    try {
+      await writeFile(lockPath, `${process.pid}\n`, {
+        flag: "wx",
+        mode: 0o600,
+        flush: true,
+      });
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        await unlink(lockPath).catch((error) => {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        });
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      let encodedOwner: string;
+      try {
+        encodedOwner = (await readFile(lockPath, "utf8")).trim();
+      } catch (readError) {
+        if ((readError as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw readError;
+      }
+      if (!/^\d+$/.test(encodedOwner)) {
+        throw new Error(`state lock is invalid; remove ${lockPath} manually`);
+      }
+      const owner = Number(encodedOwner);
+      if (owner > 0 && isProcessRunning(owner)) {
+        throw new Error(`state file is already in use by pid ${owner}`);
+      }
+      await unlink(lockPath).catch((unlinkError) => {
+        if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw unlinkError;
+        }
+      });
+    }
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
 }

--- a/packages/cli/src/localState.ts
+++ b/packages/cli/src/localState.ts
@@ -1,0 +1,78 @@
+import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export interface EncryptedStateEnvelope {
+  version: 1;
+  iv: string;
+  tag: string;
+  ciphertext: string;
+}
+
+async function readOrCreateKey(keyPath: string): Promise<Buffer> {
+  try {
+    const key = Buffer.from((await readFile(keyPath, "utf8")).trim(), "hex");
+    if (key.length !== 32) throw new Error("state key must be 32 bytes");
+    return key;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    await mkdir(dirname(keyPath), { recursive: true, mode: 0o700 });
+    const key = randomBytes(32);
+    await writeFile(keyPath, `${key.toString("hex")}\n`, { mode: 0o600 });
+    await chmod(keyPath, 0o600);
+    return key;
+  }
+}
+
+export async function loadEncryptedState<T>(
+  statePath: string,
+  keyPath: string,
+): Promise<T | undefined> {
+  let envelope: EncryptedStateEnvelope;
+  try {
+    envelope = JSON.parse(await readFile(statePath, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  if (envelope.version !== 1) throw new Error("unsupported state version");
+  const key = await readOrCreateKey(keyPath);
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    key,
+    Buffer.from(envelope.iv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(envelope.tag, "base64"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(envelope.ciphertext, "base64")),
+    decipher.final(),
+  ]);
+  return JSON.parse(plaintext.toString("utf8")) as T;
+}
+
+export async function saveEncryptedState(
+  statePath: string,
+  keyPath: string,
+  value: unknown,
+): Promise<void> {
+  const key = await readOrCreateKey(keyPath);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(value), "utf8"),
+    cipher.final(),
+  ]);
+  const envelope: EncryptedStateEnvelope = {
+    version: 1,
+    iv: iv.toString("base64"),
+    tag: cipher.getAuthTag().toString("base64"),
+    ciphertext: ciphertext.toString("base64"),
+  };
+  await mkdir(dirname(statePath), { recursive: true, mode: 0o700 });
+  // Multiple group events can request persistence concurrently. A shared
+  // `.tmp` name lets one save rename another save's file out from under it.
+  const temporary = `${statePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(envelope)}\n`, { mode: 0o600 });
+  await chmod(temporary, 0o600);
+  await rename(temporary, statePath);
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -95,7 +95,7 @@ program
   )
   .addHelpText(
     "after",
-    "\nDocumentation:\n  cordn docs [topic]  print bundled quickstart, agent, daemon, queues, or security docs",
+    "\nDocumentation:\n  cordn docs [topic]  print bundled quickstart, commands, agent, daemon, queues, or security docs",
   );
 
 const cliArgs = process.argv.slice(2);
@@ -385,6 +385,11 @@ try {
     }
     await durableQueue;
   } else {
+    if (!stateFile) {
+      console.error(
+        "warning: this session is ephemeral; restart with --state-file <path> to preserve identity and MLS state",
+      );
+    }
     await startCliRepl(activeSession, persist);
   }
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,9 +1,16 @@
 import { Command } from "commander";
+import { readFile } from "node:fs/promises";
+import { stdout } from "node:process";
 
 import { startCliRepl } from "./repl.ts";
 import { CliSession } from "./session.ts";
 import { FileMediaStore } from "./mediaStore.ts";
 import { deriveStablePubkey } from "./utils/mlsBase.ts";
+import { loadEncryptedState, saveEncryptedState } from "./localState.ts";
+import type { CliSessionSnapshot } from "./session.ts";
+import { executeReplCommand, tokenizeInput } from "./replCommands.ts";
+import { processOutbox } from "./outbox.ts";
+import { enqueueInboundMessages } from "./inbox.ts";
 
 function readOptionalStringEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
@@ -55,6 +62,7 @@ program
   .name("cordn-cli")
   .description("Minimal interactive MLS coordinator CLI")
   .option("--private-key <hex>", "hex private key for the client identity")
+  .option("--private-key-file <path>", "file containing the client private key")
   .option("--server-pubkey <hex>", "target ContextVM server public key")
   .option(
     "--relay <url>",
@@ -65,19 +73,52 @@ program
   .option(
     "--media-dir <path>",
     "directory for the local content-addressed media store (enables send-media / save-media)",
+  )
+  .option("--state-file <path>", "encrypted persistent CLI session state")
+  .option("--state-key-file <path>", "32-byte state encryption key file")
+  .option("--command <line>", "run one command non-interactively and exit")
+  .option("--daemon", "run a persistent welcome/sync writer process")
+  .option("--group-alias <alias>", "alias used when accepting a Welcome")
+  .option(
+    "--outbox-dir <path>",
+    "process JSON message jobs from this directory while in daemon mode",
+  )
+  .option(
+    "--inbox-dir <path>",
+    "write received group messages as atomic JSON jobs while in daemon mode",
   );
 
 program.parse();
 
 const options = program.opts<{
   privateKey?: string;
+  privateKeyFile?: string;
   serverPubkey?: string;
   relay: string[];
   mediaDir?: string;
+  stateFile?: string;
+  stateKeyFile?: string;
+  command?: string;
+  daemon?: boolean;
+  groupAlias?: string;
+  outboxDir?: string;
+  inboxDir?: string;
 }>();
 
+const filePrivateKey = options.privateKeyFile
+  ? (await readFile(options.privateKeyFile, "utf8")).trim()
+  : undefined;
+
+const stateFile = options.stateFile;
+const stateKeyFile =
+  options.stateKeyFile ?? (stateFile ? `${stateFile}.key` : undefined);
+const snapshot =
+  stateFile && stateKeyFile
+    ? await loadEncryptedState<CliSessionSnapshot>(stateFile, stateKeyFile)
+    : undefined;
+
 const session = new CliSession({
-  privateKey: options.privateKey,
+  privateKey: snapshot?.privateKey ?? filePrivateKey ?? options.privateKey,
   serverPubkey: options.serverPubkey ?? readDefaultCoordinatorPubkey(),
   relays: options.relay.length > 0 ? options.relay : readDefaultRelayUrls(),
   mediaStore: options.mediaDir
@@ -85,5 +126,86 @@ const session = new CliSession({
     : undefined,
 });
 
-await startCliRepl(session);
+if (snapshot) await session.restoreSnapshot(snapshot);
+
+const persist = async (): Promise<void> => {
+  if (stateFile && stateKeyFile) {
+    await saveEncryptedState(stateFile, stateKeyFile, session.exportSnapshot());
+  }
+};
+
+await persist();
+if (options.command) {
+  const [command = "", ...args] = tokenizeInput(options.command);
+  await executeReplCommand(command, args, { session, output: stdout });
+} else if (options.daemon) {
+  let stopping = false;
+  process.once("SIGINT", () => {
+    stopping = true;
+  });
+  process.once("SIGTERM", () => {
+    stopping = true;
+  });
+
+  let inboxWrite = Promise.resolve();
+  session.onGroupEvent((event) => {
+    if (
+      options.inboxDir &&
+      event.type === "messages-ingested" &&
+      event.received.length > 0
+    ) {
+      inboxWrite = inboxWrite
+        .then(() =>
+          enqueueInboundMessages(
+            options.inboxDir!,
+            event.groupAlias,
+            event.received,
+          ),
+        )
+        .then(persist)
+        .catch((error) => console.error("inbox/state write failed", error));
+    } else {
+      inboxWrite = inboxWrite
+        .then(persist)
+        .catch((error) => console.error("state save failed", error));
+    }
+  });
+
+  while (!stopping) {
+    try {
+      const welcomes = await session.fetchWelcomes();
+      const heldRefs = new Set(
+        session.listKeyPackages().map((entry) => entry.keyPackageRef),
+      );
+      for (const welcome of welcomes) {
+        if (!heldRefs.has(welcome.kp_ref)) continue;
+        const alias =
+          options.groupAlias ?? `group-${session.listGroups().length + 1}`;
+        if (session.listGroups().some((group) => group.alias === alias))
+          continue;
+        await session.acceptWelcome(welcome.kp_ref, alias);
+        await persist();
+      }
+      await session.watchAllGroups();
+      if (options.outboxDir) {
+        await processOutbox(options.outboxDir, session, {
+          defaultGroupAlias: options.groupAlias,
+          persist,
+          onSent: (name, cursor) =>
+            console.log(`outbox sent ${name} cursor=${cursor}`),
+        });
+      }
+      await persist();
+    } catch (error) {
+      console.error(
+        `daemon cycle failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+  }
+  await inboxWrite;
+} else {
+  await startCliRepl(session, persist);
+}
+await persist();
 await session.disconnect();

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { stdout } from "node:process";
 import { dirname, resolve } from "node:path";
 
@@ -17,6 +18,12 @@ import { executeReplCommand, tokenizeInput } from "./replCommands.ts";
 import { processOutbox } from "./outbox.ts";
 import { enqueueInboundMessages } from "./inbox.ts";
 import { welcomeIdentifier } from "./sessionStore.ts";
+import { DEFAULT_COORDINATOR_PUBKEY, DEFAULT_RELAY_URLS } from "./defaults.ts";
+import { readCliDoc } from "./docs.ts";
+
+const { version: cliVersion } = createRequire(import.meta.url)(
+  "../package.json",
+) as { version: string };
 
 function readOptionalStringEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
@@ -46,35 +53,22 @@ function readDefaultCoordinatorPubkey(): string | undefined {
   return deriveStablePubkey(configured);
 }
 
-// Load optional .env then .env.local (first write wins; missing files are
-// ignored). Uses Node's native process.loadEnvFile (>= 20.12), which has
-// identical semantics to the former @cordn/core env helper.
-for (const file of [".env", ".env.local"]) {
-  try {
-    process.loadEnvFile(file);
-  } catch (err) {
-    if (
-      !(err instanceof Error) ||
-      (err as NodeJS.ErrnoException).code !== "ENOENT"
-    ) {
-      throw err;
-    }
-  }
-}
-
 const program = new Command();
 
 program
-  .name("cordn-cli")
+  .name("cordn")
   .description("Persistent MLS coordinator CLI")
+  .version(cliVersion)
   .option("--private-key <hex>", "hex private key for the client identity")
   .option("--private-key-file <path>", "file containing the client private key")
-  .option("--server-pubkey <hex>", "target ContextVM server public key")
+  .option(
+    "--server-pubkey <hex>",
+    `target ContextVM server public key (default: ${DEFAULT_COORDINATOR_PUBKEY})`,
+  )
   .option(
     "--relay <url>",
-    "relay URL to use",
-    (value, current: string[]) => [...current, value],
-    [],
+    `relay URL to use; repeatable (defaults: ${DEFAULT_RELAY_URLS.join(", ")})`,
+    (value, current?: string[]) => [...(current ?? []), value],
   )
   .option(
     "--media-dir <path>",
@@ -98,7 +92,48 @@ program
   .option(
     "--inbox-dir <path>",
     "write received group messages as atomic JSON jobs while in daemon mode",
+  )
+  .addHelpText(
+    "after",
+    "\nDocumentation:\n  cordn docs [topic]  print bundled quickstart, agent, daemon, queues, or security docs",
   );
+
+const cliArgs = process.argv.slice(2);
+if (cliArgs[0] === "docs") {
+  const topic = ["--help", "-h"].includes(cliArgs[1] ?? "")
+    ? undefined
+    : cliArgs[1];
+  try {
+    if (cliArgs.length > 2) throw new Error("usage: cordn docs [topic]");
+    const content = await readCliDoc(topic);
+    await new Promise<void>((resolve, reject) => {
+      stdout.write(
+        content.endsWith("\n") ? content : `${content}\n`,
+        (error) => (error ? reject(error) : resolve()),
+      );
+    });
+    process.exit(0);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+// Load optional .env then .env.local (first write wins; missing files are
+// ignored). Uses Node's native process.loadEnvFile (>= 20.12), which has
+// identical semantics to the former @cordn/core env helper.
+for (const file of [".env", ".env.local"]) {
+  try {
+    process.loadEnvFile(file);
+  } catch (err) {
+    if (
+      !(err instanceof Error) ||
+      (err as NodeJS.ErrnoException).code !== "ENOENT"
+    ) {
+      throw err;
+    }
+  }
+}
 
 program.parse();
 
@@ -106,7 +141,7 @@ const options = program.opts<{
   privateKey?: string;
   privateKeyFile?: string;
   serverPubkey?: string;
-  relay: string[];
+  relay?: string[];
   mediaDir?: string;
   stateFile?: string;
   stateKeyFile?: string;
@@ -199,12 +234,13 @@ try {
     serverPubkey:
       options.serverPubkey ??
       savedCoordinator?.serverPubkey ??
-      readDefaultCoordinatorPubkey(),
+      readDefaultCoordinatorPubkey() ??
+      DEFAULT_COORDINATOR_PUBKEY,
     relays:
-      options.relay.length > 0
+      options.relay && options.relay.length > 0
         ? options.relay
         : ((useSavedRelays ? savedCoordinator?.relays : undefined) ??
-          readDefaultRelayUrls()),
+          readDefaultRelayUrls() ?? [...DEFAULT_RELAY_URLS]),
     mediaStore: options.mediaDir
       ? new FileMediaStore(options.mediaDir)
       : undefined,

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,16 +1,22 @@
 import { Command } from "commander";
 import { readFile } from "node:fs/promises";
 import { stdout } from "node:process";
+import { dirname, resolve } from "node:path";
 
 import { startCliRepl } from "./repl.ts";
 import { CliSession } from "./session.ts";
 import { FileMediaStore } from "./mediaStore.ts";
 import { deriveStablePubkey } from "./utils/mlsBase.ts";
-import { loadEncryptedState, saveEncryptedState } from "./localState.ts";
+import {
+  acquireStateLock,
+  loadEncryptedState,
+  saveEncryptedState,
+} from "./localState.ts";
 import type { CliSessionSnapshot } from "./session.ts";
 import { executeReplCommand, tokenizeInput } from "./replCommands.ts";
 import { processOutbox } from "./outbox.ts";
 import { enqueueInboundMessages } from "./inbox.ts";
+import { welcomeIdentifier } from "./sessionStore.ts";
 
 function readOptionalStringEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
@@ -60,7 +66,7 @@ const program = new Command();
 
 program
   .name("cordn-cli")
-  .description("Minimal interactive MLS coordinator CLI")
+  .description("Persistent MLS coordinator CLI")
   .option("--private-key <hex>", "hex private key for the client identity")
   .option("--private-key-file <path>", "file containing the client private key")
   .option("--server-pubkey <hex>", "target ContextVM server public key")
@@ -75,10 +81,16 @@ program
     "directory for the local content-addressed media store (enables send-media / save-media)",
   )
   .option("--state-file <path>", "encrypted persistent CLI session state")
-  .option("--state-key-file <path>", "32-byte state encryption key file")
+  .option(
+    "--state-key-file <path>",
+    "file containing a hex-encoded 32-byte state encryption key",
+  )
   .option("--command <line>", "run one command non-interactively and exit")
   .option("--daemon", "run a persistent welcome/sync writer process")
-  .option("--group-alias <alias>", "alias used when accepting a Welcome")
+  .option(
+    "--group-alias <alias>",
+    "Welcome alias base and default outbox group",
+  )
   .option(
     "--outbox-dir <path>",
     "process JSON message jobs from this directory while in daemon mode",
@@ -105,107 +117,256 @@ const options = program.opts<{
   inboxDir?: string;
 }>();
 
+if (options.privateKey && options.privateKeyFile) {
+  program.error("--private-key and --private-key-file are mutually exclusive");
+}
+if (options.command !== undefined && options.daemon) {
+  program.error("--command and --daemon are mutually exclusive");
+}
+if (options.stateKeyFile && !options.stateFile) {
+  program.error("--state-key-file requires --state-file");
+}
+if (
+  options.stateFile &&
+  options.stateKeyFile &&
+  resolve(options.stateFile) === resolve(options.stateKeyFile)
+) {
+  program.error("--state-file and --state-key-file must be different files");
+}
+if ((options.inboxDir || options.outboxDir) && !options.daemon) {
+  program.error("--inbox-dir/--outbox-dir require --daemon");
+}
+if (options.daemon && !options.stateFile) {
+  program.error("--daemon requires --state-file");
+}
+if (
+  options.inboxDir &&
+  options.outboxDir &&
+  resolve(options.inboxDir) === resolve(options.outboxDir)
+) {
+  program.error("--inbox-dir and --outbox-dir must be different directories");
+}
+if (
+  [options.inboxDir, options.outboxDir].some(
+    (queueDir) =>
+      queueDir &&
+      [options.stateFile, options.stateKeyFile].some(
+        (path) =>
+          (path?.endsWith(".json") || path?.endsWith(".json.processing")) &&
+          resolve(queueDir) === dirname(resolve(path)),
+      ),
+  )
+) {
+  program.error("state/key .json files cannot be inside queue directories");
+}
+
 const filePrivateKey = options.privateKeyFile
   ? (await readFile(options.privateKeyFile, "utf8")).trim()
   : undefined;
-
+const explicitPrivateKey = filePrivateKey ?? options.privateKey;
 const stateFile = options.stateFile;
 const stateKeyFile =
   options.stateKeyFile ?? (stateFile ? `${stateFile}.key` : undefined);
-const snapshot =
-  stateFile && stateKeyFile
-    ? await loadEncryptedState<CliSessionSnapshot>(stateFile, stateKeyFile)
-    : undefined;
+const releaseStateLock = stateFile
+  ? await acquireStateLock(stateFile)
+  : async () => undefined;
+let session: CliSession | undefined;
 
-const session = new CliSession({
-  privateKey: snapshot?.privateKey ?? filePrivateKey ?? options.privateKey,
-  serverPubkey: options.serverPubkey ?? readDefaultCoordinatorPubkey(),
-  relays: options.relay.length > 0 ? options.relay : readDefaultRelayUrls(),
-  mediaStore: options.mediaDir
-    ? new FileMediaStore(options.mediaDir)
-    : undefined,
-});
+try {
+  const snapshot =
+    stateFile && stateKeyFile
+      ? await loadEncryptedState<CliSessionSnapshot>(stateFile, stateKeyFile)
+      : undefined;
 
-if (snapshot) await session.restoreSnapshot(snapshot);
-
-const persist = async (): Promise<void> => {
-  if (stateFile && stateKeyFile) {
-    await saveEncryptedState(stateFile, stateKeyFile, session.exportSnapshot());
+  if (
+    snapshot &&
+    explicitPrivateKey &&
+    snapshot.privateKey.toLowerCase() !== explicitPrivateKey.toLowerCase()
+  ) {
+    throw new Error(
+      "--private-key/--private-key-file does not match the identity stored in --state-file",
+    );
   }
-};
 
-await persist();
-if (options.command) {
-  const [command = "", ...args] = tokenizeInput(options.command);
-  await executeReplCommand(command, args, { session, output: stdout });
-} else if (options.daemon) {
-  let stopping = false;
-  process.once("SIGINT", () => {
-    stopping = true;
+  const savedCoordinator = snapshot?.defaultCoordinator;
+  const useSavedRelays =
+    savedCoordinator &&
+    (!options.serverPubkey ||
+      options.serverPubkey.toLowerCase() ===
+        savedCoordinator.serverPubkey.toLowerCase());
+  const activeSession = new CliSession({
+    privateKey: snapshot?.privateKey ?? explicitPrivateKey,
+    serverPubkey:
+      options.serverPubkey ??
+      savedCoordinator?.serverPubkey ??
+      readDefaultCoordinatorPubkey(),
+    relays:
+      options.relay.length > 0
+        ? options.relay
+        : ((useSavedRelays ? savedCoordinator?.relays : undefined) ??
+          readDefaultRelayUrls()),
+    mediaStore: options.mediaDir
+      ? new FileMediaStore(options.mediaDir)
+      : undefined,
   });
-  process.once("SIGTERM", () => {
-    stopping = true;
-  });
+  session = activeSession;
+  if (snapshot) await activeSession.restoreSnapshot(snapshot);
 
-  let inboxWrite = Promise.resolve();
-  session.onGroupEvent((event) => {
-    if (
-      options.inboxDir &&
-      event.type === "messages-ingested" &&
-      event.received.length > 0
-    ) {
-      inboxWrite = inboxWrite
-        .then(() =>
-          enqueueInboundMessages(
-            options.inboxDir!,
-            event.groupAlias,
-            event.received,
-          ),
-        )
-        .then(persist)
-        .catch((error) => console.error("inbox/state write failed", error));
-    } else {
-      inboxWrite = inboxWrite
-        .then(persist)
-        .catch((error) => console.error("state save failed", error));
-    }
-  });
+  let durableQueue = Promise.resolve();
+  let durabilityError: unknown;
+  const enqueueDurableWrite = (
+    beforeSave?: () => Promise<void>,
+  ): Promise<void> => {
+    const operation = durableQueue.then(async () => {
+      if (durabilityError) throw durabilityError;
+      try {
+        await beforeSave?.();
+        if (stateFile && stateKeyFile) {
+          // ponytail: whole-snapshot rewrites stay simple; split history into
+          // append-only storage only if real save latency becomes material.
+          await saveEncryptedState(
+            stateFile,
+            stateKeyFile,
+            await activeSession.exportSnapshotWhenIdle(),
+          );
+        }
+      } catch (error) {
+        durabilityError = error;
+        throw error;
+      }
+    });
+    // Keep the queue usable as a barrier without swallowing the caller's error.
+    durableQueue = operation.catch(() => undefined);
+    return operation;
+  };
+  const persist = (): Promise<void> => enqueueDurableWrite();
 
-  while (!stopping) {
+  await persist();
+  if (options.command !== undefined) {
+    const [command = "", ...args] = tokenizeInput(options.command);
     try {
-      const welcomes = await session.fetchWelcomes();
-      const heldRefs = new Set(
-        session.listKeyPackages().map((entry) => entry.keyPackageRef),
-      );
-      for (const welcome of welcomes) {
-        if (!heldRefs.has(welcome.kp_ref)) continue;
-        const alias =
-          options.groupAlias ?? `group-${session.listGroups().length + 1}`;
-        if (session.listGroups().some((group) => group.alias === alias))
-          continue;
-        await session.acceptWelcome(welcome.kp_ref, alias);
-        await persist();
-      }
-      await session.watchAllGroups();
-      if (options.outboxDir) {
-        await processOutbox(options.outboxDir, session, {
-          defaultGroupAlias: options.groupAlias,
-          persist,
-          onSent: (name, cursor) =>
-            console.log(`outbox sent ${name} cursor=${cursor}`),
-        });
-      }
-      await persist();
+      await executeReplCommand(command, args, {
+        session: activeSession,
+        output: stdout,
+      });
     } catch (error) {
-      console.error(
-        `daemon cycle failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
     }
-    await new Promise((resolve) => setTimeout(resolve, 5_000));
+  } else if (options.daemon) {
+    let stopping = false;
+    process.once("SIGINT", () => {
+      stopping = true;
+    });
+    process.once("SIGTERM", () => {
+      stopping = true;
+    });
+
+    const stopOnDurabilityFailure = (error: unknown): void => {
+      console.error(
+        `inbox/state write failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      durabilityError = error;
+      stopping = true;
+      process.exitCode = 1;
+    };
+    activeSession.onGroupEvent((event) => {
+      if (event.type !== "messages-ingested") return;
+      const writeInbox =
+        options.inboxDir && event.received.length > 0
+          ? () =>
+              enqueueInboundMessages(
+                options.inboxDir!,
+                event.groupAlias,
+                event.received,
+              )
+          : undefined;
+      void enqueueDurableWrite(writeInbox).catch(stopOnDurabilityFailure);
+    });
+
+    while (!stopping) {
+      try {
+        let welcomes = activeSession.listWelcomes();
+        try {
+          welcomes = await activeSession.fetchWelcomes();
+        } catch (error) {
+          console.error(
+            `welcome fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        const heldRefs = new Set(
+          activeSession
+            .listKeyPackages()
+            .filter((entry) => !entry.consumed || entry.isLastResort)
+            .map((entry) => entry.keyPackageRef),
+        );
+        for (const welcome of welcomes) {
+          if (!heldRefs.has(welcome.kp_ref)) continue;
+          const alias = uniqueGroupAlias(
+            activeSession,
+            options.groupAlias ??
+              `group-${activeSession.listGroups().length + 1}`,
+          );
+          try {
+            await activeSession.acceptWelcome(
+              welcomeIdentifier(welcome),
+              alias,
+            );
+          } catch (error) {
+            // One bad Welcome must not stop syncing or the outbox for the rest.
+            console.error(
+              `accepting welcome ${welcomeIdentifier(welcome)} failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+            continue;
+          }
+          await persist();
+        }
+        await activeSession.watchAllGroups();
+        if (options.outboxDir) {
+          await processOutbox(options.outboxDir, activeSession, {
+            defaultGroupAlias: options.groupAlias,
+            persist,
+            onSent: (name, cursor) =>
+              console.log(`outbox sent ${name} cursor=${cursor}`),
+          });
+        }
+        // Fetch-only Welcome changes are replayable/idempotent; avoid rewriting
+        // the full history every five seconds when nothing durable changed.
+      } catch (error) {
+        console.error(
+          `daemon cycle failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        if (durabilityError) {
+          stopping = true;
+          process.exitCode = 1;
+        }
+      }
+      if (!stopping) {
+        await new Promise((resolve) => setTimeout(resolve, 5_000));
+      }
+    }
+    await durableQueue;
+  } else {
+    await startCliRepl(activeSession, persist);
   }
-  await inboxWrite;
-} else {
-  await startCliRepl(session, persist);
+
+  // Stop live ingestion before the final durability barrier; otherwise a
+  // message can land after the last snapshot but before finally disconnects.
+  await activeSession.disconnect();
+  if (!durabilityError) await persist();
+  else process.exitCode = 1;
+} finally {
+  await session?.disconnect();
+  await releaseStateLock();
 }
-await persist();
-await session.disconnect();
+
+function uniqueGroupAlias(session: CliSession, base: string): string {
+  const taken = new Set(session.listGroups().map((group) => group.alias));
+  if (!taken.has(base)) return base;
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${base}-${suffix}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}

--- a/packages/cli/src/membershipFlow.ts
+++ b/packages/cli/src/membershipFlow.ts
@@ -98,6 +98,7 @@ export async function prepareAddMember(params: {
       keyPackageReference: consumeResult.keyPackage.keyPackageRef,
       targetStablePubkey: consumeResult.keyPackage.stablePubkey,
       welcomeBase64: encodeWelcomeBase64(commitResult.welcome),
+      localStateApplied: false,
       status: "pending",
     },
   };
@@ -156,6 +157,7 @@ export async function prepareRemoveMember(params: {
       groupId: params.deriveGroupId(params.group.state),
       commitMessageBase64: commitResult.commitMessageBase64,
       targetStablePubkey: params.targetStablePubkey,
+      localStateApplied: false,
       status: "pending",
     },
   };

--- a/packages/cli/src/outbox.test.ts
+++ b/packages/cli/src/outbox.test.ts
@@ -56,4 +56,74 @@ describe("persistent outbox", () => {
     });
     expect(await readdir(directory)).toEqual(["001.json"]);
   });
+
+  test("quarantines invalid jobs without blocking later jobs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-outbox-"));
+    await writeFile(join(directory, "001.json"), "null");
+    await writeFile(
+      join(directory, "002.json"),
+      JSON.stringify({ groupAlias: "office", message: 42 }),
+    );
+    await writeFile(
+      join(directory, "003.json"),
+      JSON.stringify({ groupAlias: 42, message: "wrong target" }),
+    );
+    await writeFile(
+      join(directory, "004.json"),
+      JSON.stringify({ groupAlias: "office", message: "ok" }),
+    );
+    const sendMessage = vi.fn().mockResolvedValue({ cursor: 1 });
+
+    await processOutbox(directory, { sendMessage }, {});
+
+    expect(sendMessage.mock.calls).toEqual([["office", "ok"]]);
+    expect(await readdir(directory)).toEqual([
+      "001.json.invalid",
+      "002.json.invalid",
+      "003.json.invalid",
+    ]);
+  });
+
+  test("finishes an orphan before a new job reusing its base name", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-outbox-"));
+    await writeFile(
+      join(directory, "001.json.processing"),
+      JSON.stringify({ message: "orphan" }),
+    );
+    await writeFile(
+      join(directory, "001.json"),
+      JSON.stringify({ message: "new" }),
+    );
+    const sendMessage = vi.fn().mockResolvedValue({ cursor: 4 });
+
+    await processOutbox(
+      directory,
+      { sendMessage },
+      { defaultGroupAlias: "office" },
+    );
+
+    expect(sendMessage.mock.calls).toEqual([
+      ["office", "orphan"],
+      ["office", "new"],
+    ]);
+    expect(await readdir(directory)).toEqual([]);
+  });
+
+  test("adopts a job orphaned mid-processing", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-outbox-"));
+    await writeFile(
+      join(directory, "001.json.processing"),
+      JSON.stringify({ message: "resumed" }),
+    );
+    const sendMessage = vi.fn().mockResolvedValue({ cursor: 4 });
+
+    await processOutbox(
+      directory,
+      { sendMessage },
+      { defaultGroupAlias: "office" },
+    );
+
+    expect(sendMessage.mock.calls).toEqual([["office", "resumed"]]);
+    expect(await readdir(directory)).toEqual([]);
+  });
 });

--- a/packages/cli/src/outbox.test.ts
+++ b/packages/cli/src/outbox.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test, vi } from "vitest";
+
+import { processOutbox } from "./outbox.ts";
+
+describe("persistent outbox", () => {
+  test("sends jobs in filename order and removes successful jobs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-outbox-"));
+    await writeFile(
+      join(directory, "002.json"),
+      JSON.stringify({ message: "two" }),
+    );
+    await writeFile(
+      join(directory, "001.json"),
+      JSON.stringify({ groupAlias: "other", message: "one" }),
+    );
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ cursor: 1 })
+      .mockResolvedValueOnce({ cursor: 2 });
+    const persist = vi.fn();
+
+    await processOutbox(
+      directory,
+      { sendMessage },
+      {
+        defaultGroupAlias: "default",
+        persist,
+      },
+    );
+
+    expect(sendMessage.mock.calls).toEqual([
+      ["other", "one"],
+      ["default", "two"],
+    ]);
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(await readdir(directory)).toEqual([]);
+  });
+
+  test("puts a failed job back for retry", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cordn-outbox-"));
+    const jobPath = join(directory, "001.json");
+    await writeFile(jobPath, JSON.stringify({ message: "retry" }));
+    const sender = {
+      sendMessage: vi.fn().mockRejectedValue(new Error("offline")),
+    };
+
+    await expect(
+      processOutbox(directory, sender, { defaultGroupAlias: "group" }),
+    ).rejects.toThrow("offline");
+
+    expect(JSON.parse(await readFile(jobPath, "utf8"))).toEqual({
+      message: "retry",
+    });
+    expect(await readdir(directory)).toEqual(["001.json"]);
+  });
+});

--- a/packages/cli/src/outbox.ts
+++ b/packages/cli/src/outbox.ts
@@ -1,0 +1,50 @@
+import { mkdir, readFile, readdir, rename, unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface OutboxSender {
+  sendMessage(groupAlias: string, message: string): Promise<{ cursor: number }>;
+}
+
+export async function processOutbox(
+  outboxDir: string,
+  sender: OutboxSender,
+  options: {
+    defaultGroupAlias?: string;
+    persist?: () => Promise<void>;
+    onSent?: (name: string, cursor: number) => void;
+  } = {},
+): Promise<void> {
+  await mkdir(outboxDir, { recursive: true, mode: 0o700 });
+  const entries = (await readdir(outboxDir))
+    .filter((name) => name.endsWith(".json"))
+    .sort();
+
+  for (const name of entries) {
+    const queuedPath = join(outboxDir, name);
+    const processingPath = `${queuedPath}.processing`;
+    try {
+      await rename(queuedPath, processingPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
+
+    try {
+      const job = JSON.parse(await readFile(processingPath, "utf8")) as {
+        groupAlias?: string;
+        message?: string;
+      };
+      const groupAlias = job.groupAlias?.trim() || options.defaultGroupAlias;
+      const message = job.message?.trim();
+      if (!groupAlias || !message) throw new Error("invalid outbox job");
+
+      const stored = await sender.sendMessage(groupAlias, message);
+      await options.persist?.();
+      await unlink(processingPath);
+      options.onSent?.(name, stored.cursor);
+    } catch (error) {
+      await rename(processingPath, queuedPath).catch(() => undefined);
+      throw error;
+    }
+  }
+}

--- a/packages/cli/src/outbox.ts
+++ b/packages/cli/src/outbox.ts
@@ -1,7 +1,10 @@
 import { mkdir, readFile, readdir, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 
-export interface OutboxSender {
+const PROCESSING_SUFFIX = ".processing";
+const INVALID_SUFFIX = ".invalid";
+
+interface OutboxSender {
   sendMessage(groupAlias: string, message: string): Promise<{ cursor: number }>;
 }
 
@@ -16,32 +19,79 @@ export async function processOutbox(
 ): Promise<void> {
   await mkdir(outboxDir, { recursive: true, mode: 0o700 });
   const entries = (await readdir(outboxDir))
-    .filter((name) => name.endsWith(".json"))
-    .sort();
+    .filter(
+      (name) =>
+        name.endsWith(".json") || name.endsWith(`.json${PROCESSING_SUFFIX}`),
+    )
+    .sort((left, right) => {
+      const leftBase = left.endsWith(PROCESSING_SUFFIX)
+        ? left.slice(0, -PROCESSING_SUFFIX.length)
+        : left;
+      const rightBase = right.endsWith(PROCESSING_SUFFIX)
+        ? right.slice(0, -PROCESSING_SUFFIX.length)
+        : right;
+      const baseOrder =
+        leftBase < rightBase ? -1 : leftBase > rightBase ? 1 : 0;
+      return (
+        baseOrder ||
+        Number(right.endsWith(PROCESSING_SUFFIX)) -
+          Number(left.endsWith(PROCESSING_SUFFIX))
+      );
+    });
 
   for (const name of entries) {
-    const queuedPath = join(outboxDir, name);
-    const processingPath = `${queuedPath}.processing`;
+    // A `.processing` leftover means a previous run crashed mid-job; adopt it
+    // instead of orphaning it behind the `.json` filter forever.
+    const base = name.endsWith(PROCESSING_SUFFIX)
+      ? name.slice(0, -PROCESSING_SUFFIX.length)
+      : name;
+    const queuedPath = join(outboxDir, base);
+    const processingPath = `${queuedPath}${PROCESSING_SUFFIX}`;
+
+    if (base === name) {
+      try {
+        await rename(queuedPath, processingPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw error;
+      }
+    }
+
+    let job: unknown;
     try {
-      await rename(queuedPath, processingPath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-      throw error;
+      job = JSON.parse(await readFile(processingPath, "utf8"));
+    } catch {
+      await rename(processingPath, `${queuedPath}${INVALID_SUFFIX}`);
+      continue;
+    }
+    if (!job || typeof job !== "object" || Array.isArray(job)) {
+      await rename(processingPath, `${queuedPath}${INVALID_SUFFIX}`);
+      continue;
+    }
+    const candidate = job as Record<string, unknown>;
+    if (
+      candidate.groupAlias !== undefined &&
+      typeof candidate.groupAlias !== "string"
+    ) {
+      await rename(processingPath, `${queuedPath}${INVALID_SUFFIX}`);
+      continue;
+    }
+    const groupAlias =
+      candidate.groupAlias?.trim() || options.defaultGroupAlias?.trim();
+    const message =
+      typeof candidate.message === "string" && candidate.message.trim()
+        ? candidate.message
+        : undefined;
+    if (!groupAlias || !message) {
+      await rename(processingPath, `${queuedPath}${INVALID_SUFFIX}`);
+      continue;
     }
 
     try {
-      const job = JSON.parse(await readFile(processingPath, "utf8")) as {
-        groupAlias?: string;
-        message?: string;
-      };
-      const groupAlias = job.groupAlias?.trim() || options.defaultGroupAlias;
-      const message = job.message?.trim();
-      if (!groupAlias || !message) throw new Error("invalid outbox job");
-
       const stored = await sender.sendMessage(groupAlias, message);
       await options.persist?.();
       await unlink(processingPath);
-      options.onSent?.(name, stored.cursor);
+      options.onSent?.(base, stored.cursor);
     } catch (error) {
       await rename(processingPath, queuedPath).catch(() => undefined);
       throw error;

--- a/packages/cli/src/pendingEpochOperations.test.ts
+++ b/packages/cli/src/pendingEpochOperations.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  confirmPendingEpochOperations,
+  dropPendingAddMemberForTarget,
+  enqueuePendingEpochOperation,
+  type PendingEpochOperation,
+} from "./pendingEpochOperations.ts";
+
+describe("pending epoch operations", () => {
+  test("retries a confirmed Welcome finalizer after a transient failure", async () => {
+    const pending = new Map<string, PendingEpochOperation[]>();
+    enqueuePendingEpochOperation(pending, {
+      kind: "add-member",
+      groupAlias: "office",
+      groupId: "gid",
+      commitMessageBase64: "commit",
+      keyPackageReference: "kp-ref",
+      targetStablePubkey: "bob",
+      welcomeBase64: "welcome",
+      status: "pending",
+    });
+    const StoreWelcome = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce({ at: 1 });
+    const client = { StoreWelcome } as never;
+
+    await expect(
+      confirmPendingEpochOperations(pending, client, {
+        groupAlias: "office",
+        opaqueMessageBase64s: ["commit"],
+      }),
+    ).rejects.toThrow("offline");
+    expect(pending.get("office")?.[0]?.status).toBe("confirmed");
+
+    await expect(
+      confirmPendingEpochOperations(pending, client, {
+        groupAlias: "office",
+        opaqueMessageBase64s: [],
+      }),
+    ).resolves.toBe(1);
+    expect(pending.has("office")).toBe(false);
+  });
+
+  test("drops only a stale add Welcome when that target is removed", () => {
+    const pending = new Map<string, PendingEpochOperation[]>();
+    enqueuePendingEpochOperation(pending, {
+      kind: "add-member",
+      groupAlias: "office",
+      groupId: "gid",
+      commitMessageBase64: "add",
+      keyPackageReference: "kp-ref",
+      targetStablePubkey: "bob",
+      welcomeBase64: "welcome",
+      status: "pending",
+    });
+    enqueuePendingEpochOperation(pending, {
+      kind: "remove-member",
+      groupAlias: "office",
+      groupId: "gid",
+      commitMessageBase64: "remove",
+      targetStablePubkey: "bob",
+      status: "pending",
+    });
+
+    dropPendingAddMemberForTarget(pending, "office", "bob");
+
+    expect(pending.get("office")?.map((operation) => operation.kind)).toEqual([
+      "remove-member",
+    ]);
+  });
+});

--- a/packages/cli/src/pendingEpochOperations.ts
+++ b/packages/cli/src/pendingEpochOperations.ts
@@ -14,6 +14,11 @@ export interface PendingEpochOperationBase {
    *  Used to match self-echos before decryption so the creator
    *  can confirm the operation even after adopting the new state. */
   postedMsgBase64?: string;
+  /** False while PostGroupMessage is unresolved. If a restart observes the
+   *  self-echo from this state, it must apply the Commit instead of assuming
+   *  the post-Commit ClientState was already adopted. Older snapshots omit it
+   *  and therefore retain the historical "already applied" behavior. */
+  localStateApplied?: boolean;
   status: PendingEpochOperationStatus;
 }
 
@@ -44,43 +49,17 @@ export interface PendingUpdateGroupMetadataOperation extends PendingEpochOperati
   kind: "update-group-metadata";
 }
 
-export interface PendingEpochOperationFinalizerContext {
-  client: cordnClient;
-}
-
-type PendingEpochOperationFinalizer = (
-  operation: PendingEpochOperation,
-  context: PendingEpochOperationFinalizerContext,
-) => Promise<void>;
-
-const pendingEpochOperationFinalizers: Record<
-  PendingEpochOperationKind,
-  PendingEpochOperationFinalizer
-> = {
-  "add-member": async (operation, context) => {
-    if (operation.kind !== "add-member") {
-      throw new Error("Expected add-member pending operation");
-    }
-
-    await context.client.StoreWelcome({
-      target_pk: operation.targetStablePubkey,
-      kp_ref: operation.keyPackageReference,
-      welcome_64: operation.welcomeBase64,
-      after: operation.joinAfterCursor,
-    });
-  },
-  // Remove commits require no coordinator-side finalization
-  // because there is no welcome to store.
-  "remove-member": async () => undefined,
-  // Metadata updates require no coordinator-side finalization.
-  "update-group-metadata": async () => undefined,
-};
-
 async function finalizePendingEpochOperation(
   operation: PendingEpochOperation,
-  context: PendingEpochOperationFinalizerContext,
+  client: cordnClient,
 ): Promise<void> {
-  await pendingEpochOperationFinalizers[operation.kind](operation, context);
+  if (operation.kind !== "add-member") return;
+  await client.StoreWelcome({
+    target_pk: operation.targetStablePubkey,
+    kp_ref: operation.keyPackageReference,
+    welcome_64: operation.welcomeBase64,
+    after: operation.joinAfterCursor,
+  });
 }
 
 function partitionPendingEpochOperations(
@@ -118,11 +97,11 @@ export async function confirmPendingEpochOperations(
     groupAlias: string;
     opaqueMessageBase64s: string[];
   },
-): Promise<void> {
+): Promise<number> {
   const pending = pendingEpochOperations.get(params.groupAlias);
 
   if (!pending || pending.length === 0) {
-    return;
+    return 0;
   }
 
   if (params.opaqueMessageBase64s.length > 0) {
@@ -136,50 +115,23 @@ export async function confirmPendingEpochOperations(
     }
   }
 
-  const remaining: PendingEpochOperation[] = [];
-
-  for (const operation of pending) {
-    if (operation.status === "confirmed") {
-      await finalizePendingEpochOperation(operation, { client });
-      continue;
+  let finalized = 0;
+  for (const operation of [...pending]) {
+    if (operation.status !== "confirmed") continue;
+    await finalizePendingEpochOperation(operation, client);
+    // Commit each successful finalizer immediately. If a later Welcome fails,
+    // retry only that one rather than duplicating records already stored.
+    const remaining = (
+      pendingEpochOperations.get(params.groupAlias) ?? []
+    ).filter((candidate) => candidate !== operation);
+    if (remaining.length === 0) {
+      pendingEpochOperations.delete(params.groupAlias);
+    } else {
+      pendingEpochOperations.set(params.groupAlias, remaining);
     }
-
-    remaining.push(operation);
+    finalized += 1;
   }
-
-  if (remaining.length === 0) {
-    pendingEpochOperations.delete(params.groupAlias);
-    return;
-  }
-
-  pendingEpochOperations.set(params.groupAlias, remaining);
-}
-
-export function markPendingEpochOperationsConfirmed(
-  pendingEpochOperations: Map<string, PendingEpochOperation[]>,
-  params: {
-    groupAlias: string;
-    opaqueMessageBase64s: string[];
-  },
-): void {
-  const pending = pendingEpochOperations.get(params.groupAlias);
-
-  if (
-    !pending ||
-    pending.length === 0 ||
-    params.opaqueMessageBase64s.length === 0
-  ) {
-    return;
-  }
-
-  const { matched } = partitionPendingEpochOperations(
-    pending,
-    params.opaqueMessageBase64s,
-  );
-
-  for (const operation of matched) {
-    operation.status = "confirmed";
-  }
+  return finalized;
 }
 
 export function getPendingEpochOperation(
@@ -198,13 +150,29 @@ export function getPendingEpochOperation(
   );
 }
 
-export async function rejectPendingEpochOperations(
+export function dropPendingAddMemberForTarget(
+  pendingEpochOperations: Map<string, PendingEpochOperation[]>,
+  groupAlias: string,
+  targetStablePubkey: string,
+): void {
+  const pending = pendingEpochOperations.get(groupAlias);
+  if (!pending?.length) return;
+  const remaining = pending.filter(
+    (operation) =>
+      operation.kind !== "add-member" ||
+      operation.targetStablePubkey !== targetStablePubkey,
+  );
+  if (remaining.length === 0) pendingEpochOperations.delete(groupAlias);
+  else pendingEpochOperations.set(groupAlias, remaining);
+}
+
+export function rejectPendingEpochOperations(
   pendingEpochOperations: Map<string, PendingEpochOperation[]>,
   params: {
     groupAlias: string;
     opaqueMessageBase64s: string[];
   },
-): Promise<void> {
+): void {
   const pending = pendingEpochOperations.get(params.groupAlias);
 
   if (

--- a/packages/cli/src/repl.test.ts
+++ b/packages/cli/src/repl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+
+import { isReplAbort } from "./repl.ts";
+
+describe("CLI REPL", () => {
+  test("treats readline Ctrl+C as a graceful exit", () => {
+    expect(
+      isReplAbort(
+        Object.assign(new Error("Aborted with Ctrl+C"), {
+          code: "ABORT_ERR",
+        }),
+      ),
+    ).toBe(true);
+    expect(isReplAbort(new Error("network failed"))).toBe(false);
+  });
+});

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -34,6 +34,16 @@ export async function startCliRepl(
     rl.prompt(true);
   };
 
+  const persistSafely = async (): Promise<void> => {
+    try {
+      await persist();
+    } catch (error) {
+      output.write(
+        `${colorize(`state save failed: ${error instanceof Error ? error.message : String(error)}`, ansi.red)}\n`,
+      );
+    }
+  };
+
   const unsubscribeWatchEvents = session.onGroupEvent((event) => {
     if (event.groupAlias !== selectedGroupAlias) {
       return;
@@ -86,6 +96,8 @@ export async function startCliRepl(
             output.write(
               `${colorize(error instanceof Error ? error.message : String(error), ansi.red)}\n`,
             );
+          } finally {
+            await persistSafely();
           }
         }
         continue;
@@ -97,12 +109,13 @@ export async function startCliRepl(
       if (selectedGroupAlias && !knownCommands.has(command)) {
         try {
           const stored = await session.sendMessage(selectedGroupAlias, line);
-          await persist();
           output.write(`sent cursor=${stored.cursor}\n`);
         } catch (error) {
           output.write(
             `${error instanceof Error ? error.message : String(error)}\n`,
           );
+        } finally {
+          await persistSafely();
         }
         continue;
       }
@@ -115,7 +128,6 @@ export async function startCliRepl(
         });
 
         selectedGroupAlias = result.selectedGroupAlias;
-        await persist();
         renderPrompt();
 
         if (result.shouldExit) {
@@ -125,6 +137,8 @@ export async function startCliRepl(
         output.write(
           `${colorize(error instanceof Error ? error.message : String(error), ansi.red)}\n`,
         );
+      } finally {
+        await persistSafely();
       }
     }
   } finally {

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -15,6 +15,13 @@ import {
   printHelp,
 } from "./replFormat.ts";
 
+export function isReplAbort(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code === "ABORT_ERR"
+  );
+}
+
 export async function startCliRepl(
   session: CliSession,
   persist: () => Promise<void> = async () => undefined,
@@ -83,7 +90,13 @@ export async function startCliRepl(
     while (true) {
       renderPrompt();
       rl.setPrompt(currentPrompt);
-      const line = (await rl.question(currentPrompt)).trim();
+      let line: string;
+      try {
+        line = (await rl.question(currentPrompt)).trim();
+      } catch (error) {
+        if (isReplAbort(error)) return;
+        throw error;
+      }
 
       if (!line) {
         if (selectedGroupAlias) {

--- a/packages/cli/src/repl.ts
+++ b/packages/cli/src/repl.ts
@@ -15,7 +15,10 @@ import {
   printHelp,
 } from "./replFormat.ts";
 
-export async function startCliRepl(session: CliSession): Promise<void> {
+export async function startCliRepl(
+  session: CliSession,
+  persist: () => Promise<void> = async () => undefined,
+): Promise<void> {
   const rl = createInterface({ input, output });
   let selectedGroupAlias: string | undefined;
   let currentPrompt = "cordn> ";
@@ -94,6 +97,7 @@ export async function startCliRepl(session: CliSession): Promise<void> {
       if (selectedGroupAlias && !knownCommands.has(command)) {
         try {
           const stored = await session.sendMessage(selectedGroupAlias, line);
+          await persist();
           output.write(`sent cursor=${stored.cursor}\n`);
         } catch (error) {
           output.write(
@@ -111,6 +115,7 @@ export async function startCliRepl(session: CliSession): Promise<void> {
         });
 
         selectedGroupAlias = result.selectedGroupAlias;
+        await persist();
         renderPrompt();
 
         if (result.shouldExit) {

--- a/packages/cli/src/replCommands.test.ts
+++ b/packages/cli/src/replCommands.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { PassThrough } from "node:stream";
 
 import { describe, expect, test, vi } from "vitest";
@@ -96,6 +97,24 @@ describe("parseUpdateGroupMetadataArgs", () => {
     expect(() =>
       parseUpdateGroupMetadataArgs(["demo", "--description", "hello"]),
     ).toThrow(CliUsageError);
+  });
+});
+
+describe("REPL command catalog", () => {
+  test("matches every executable switch branch", async () => {
+    const source = await readFile(
+      new URL("./replCommands.ts", import.meta.url),
+      "utf8",
+    );
+    const start = source.indexOf("switch (command)");
+    const end = source.indexOf("    default: {", start);
+    const implemented = new Set(
+      [...source.slice(start, end).matchAll(/case \"([^\"]+)\"/g)].map(
+        (match) => match[1],
+      ),
+    );
+
+    expect(implemented).toEqual(knownCommands);
   });
 });
 
@@ -218,6 +237,26 @@ describe("executeReplCommand", () => {
     expect(knownCommands.has("kps")).toBe(true);
   });
 
+  test("publishes a previously local-only key package", async () => {
+    const output = new PassThrough();
+    const publishKeyPackage = vi.fn().mockResolvedValue({
+      alias: "alice-main",
+      keyPackageRef: "alice-ref",
+      publishedAt: 123,
+    });
+    const session = { publishKeyPackage } as never;
+
+    await executeReplCommand(
+      "publish-kp",
+      ["alice-main", "--coordinator", "coordinator-a"],
+      { session, output },
+    );
+
+    expect(publishKeyPackage).toHaveBeenCalledWith("alice-main", {
+      coordinatorKey: "coordinator-a",
+    });
+  });
+
   test("supports delete-kp", async () => {
     const output = new PassThrough();
     const deleteKeyPackage = vi.fn().mockResolvedValue({
@@ -261,6 +300,27 @@ describe("executeReplCommand", () => {
 
     expect(listAvailableKeyPackageSummaries).toHaveBeenCalledWith(
       "a".repeat(64),
+    );
+  });
+
+  test("does not treat request-join options as its key package alias", async () => {
+    const output = new PassThrough();
+    const storeJoinRequest = vi.fn().mockResolvedValue({
+      keyPackageRef: "alice-ref",
+      at: 123,
+    });
+    const session = { storeJoinRequest } as never;
+
+    await executeReplCommand(
+      "request-join",
+      ["group-id", "--coordinator", "coordinator-a", "alice-main"],
+      { session, output },
+    );
+
+    expect(storeJoinRequest).toHaveBeenCalledWith(
+      "group-id",
+      "alice-main",
+      "coordinator-a",
     );
   });
 

--- a/packages/cli/src/replCommands.test.ts
+++ b/packages/cli/src/replCommands.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import {
   executeReplCommand,
+  knownCommands,
   parseCreateGroupArgs,
   parseUpdateGroupMetadataArgs,
 } from "./replCommands.ts";
@@ -214,6 +215,7 @@ describe("executeReplCommand", () => {
     });
 
     expect(listKeyPackageSummaries).toHaveBeenCalledOnce();
+    expect(knownCommands.has("kps")).toBe(true);
   });
 
   test("supports delete-kp", async () => {

--- a/packages/cli/src/replCommands.ts
+++ b/packages/cli/src/replCommands.ts
@@ -22,6 +22,7 @@ import {
   printHelp,
 } from "./replFormat.ts";
 import { CliUsageError, UnknownCommandError } from "./sessionErrors.ts";
+import { welcomeIdentifier } from "./sessionStore.ts";
 
 export const knownCommands = new Set([
   "help",
@@ -473,13 +474,13 @@ export async function executeReplCommand(
         parseCoordinatorOption(args),
       );
       output.write(
-        `${formatList(welcomes.map((welcome) => `${formatWelcomeKeyPackageReference(welcome.kp_ref)} keyPackageRef=${formatKeyPackageRef(welcome.kp_ref)}`))}\n`,
+        `${formatList(welcomes.map((welcome) => `${formatWelcomeKeyPackageReference(welcomeIdentifier(welcome))} keyPackageRef=${formatKeyPackageRef(welcome.kp_ref)} at=${welcome.at}`))}\n`,
       );
       break;
     }
     case "welcomes": {
       output.write(
-        `${formatList(session.listWelcomes().map((welcome) => `${formatWelcomeKeyPackageReference(welcome.kp_ref)} keyPackageRef=${formatKeyPackageRef(welcome.kp_ref)}`))}\n`,
+        `${formatList(session.listWelcomes().map((welcome) => `${formatWelcomeKeyPackageReference(welcomeIdentifier(welcome))} keyPackageRef=${formatKeyPackageRef(welcome.kp_ref)} at=${welcome.at}`))}\n`,
       );
       break;
     }
@@ -527,7 +528,7 @@ export async function executeReplCommand(
     case "accept-welcome": {
       if (!positionalArgs[0]) {
         throw new CliUsageError(
-          "Usage: accept-welcome <keyPackageReference> [groupAlias] [--coordinator <pubkey>] [--watch]",
+          "Usage: accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--coordinator <pubkey>] [--watch]",
         );
       }
       const group = await session.acceptWelcome(

--- a/packages/cli/src/replCommands.ts
+++ b/packages/cli/src/replCommands.ts
@@ -30,6 +30,7 @@ export const knownCommands = new Set([
   "whoami",
   "gen-kp",
   "key-packages",
+  "kps",
   "delete-kp",
   "available-kps",
   "create-group",

--- a/packages/cli/src/replCommands.ts
+++ b/packages/cli/src/replCommands.ts
@@ -20,47 +20,14 @@ import {
   formatSyncResult,
   formatWelcomeKeyPackageReference,
   printHelp,
+  REPL_COMMAND_HELP,
 } from "./replFormat.ts";
 import { CliUsageError, UnknownCommandError } from "./sessionErrors.ts";
 import { welcomeIdentifier } from "./sessionStore.ts";
 
-export const knownCommands = new Set([
-  "help",
-  "status",
-  "whoami",
-  "gen-kp",
-  "key-packages",
-  "kps",
-  "delete-kp",
-  "available-kps",
-  "create-group",
-  "update-group-metadata",
-  "set-metadata",
-  "groups",
-  "group-info",
-  "group",
-  "use",
-  "leave",
-  "unwatch",
-  "add-member",
-  "remove-member",
-  "fetch-welcomes",
-  "welcomes",
-  "accept-welcome",
-  "send",
-  "send-to",
-  "send-media",
-  "save-media",
-  "sync",
-  "sync-all",
-  "watch-all",
-  "messages",
-  "issues",
-  "fetch-join-requests",
-  "request-join",
-  "exit",
-  "quit",
-]);
+export const knownCommands = new Set<string>(
+  REPL_COMMAND_HELP.flatMap(({ names }) => [...names]),
+);
 
 export interface ReplCommandContext {
   session: CliSession;
@@ -343,6 +310,21 @@ export async function executeReplCommand(
       );
       break;
     }
+    case "publish-kp": {
+      const alias = positionalArgs[0];
+      if (!alias) {
+        throw new CliUsageError(
+          "Usage: publish-kp <alias> [--coordinator <pubkey>]",
+        );
+      }
+      const result = await session.publishKeyPackage(alias, {
+        coordinatorKey: parseCoordinatorOption(args),
+      });
+      output.write(
+        `${colorize("published", ansi.green)} alias=${result.alias} ref=${formatKeyPackageRef(result.keyPackageRef)} at=${colorize(String(result.publishedAt), ansi.dim)}\n`,
+      );
+      break;
+    }
     case "kps":
     case "key-packages": {
       output.write(
@@ -351,12 +333,13 @@ export async function executeReplCommand(
       break;
     }
     case "delete-kp": {
-      if (!args[0]) {
+      const aliasOrKeyPackageRef = positionalArgs[0];
+      if (!aliasOrKeyPackageRef) {
         throw new CliUsageError(
           "Usage: delete-kp <aliasOrKeyPackageRef> [--local-only] [--coordinator <pubkey>]",
         );
       }
-      const result = await session.deleteKeyPackage(args[0], {
+      const result = await session.deleteKeyPackage(aliasOrKeyPackageRef, {
         localOnly: args.includes("--local-only"),
         coordinatorKey: parseCoordinatorOption(args),
       });
@@ -418,12 +401,14 @@ export async function executeReplCommand(
     }
     case "group":
     case "use": {
-      if (!args[0]) throw new CliUsageError("Usage: use <groupAlias>");
-      const group = session.getGroup(args[0]);
+      const alias = positionalArgs[0];
+      if (!alias)
+        throw new CliUsageError(`Usage: ${command} <groupAlias> [--watch]`);
+      const group = session.getGroup(alias);
       if (args.includes("--watch")) {
-        await session.watchGroup(args[0]);
+        await session.watchGroup(alias);
       }
-      selectedGroupAlias = args[0];
+      selectedGroupAlias = alias;
       output.write(
         `${colorize("selected group", ansi.green)} ${colorize(selectedGroupAlias, ansi.cyan)} ${formatGroupMetadata(group.metadata)}\n`,
       );
@@ -503,14 +488,14 @@ export async function executeReplCommand(
       break;
     }
     case "request-join": {
-      if (!args[0]) {
+      const gid = positionalArgs[0];
+      if (!gid) {
         throw new CliUsageError(
           "Usage: request-join <gid> [keyPackageAlias] [--coordinator <pubkey>]",
         );
       }
-      const gid = args[0];
       const keyPackageAlias =
-        args[1] ?? session.listKeyPackageSummaries()[0]?.alias;
+        positionalArgs[1] ?? session.listKeyPackageSummaries()[0]?.alias;
       if (!keyPackageAlias) {
         throw new CliUsageError(
           "No key package available and none specified. Generate one with gen-kp first.",

--- a/packages/cli/src/replFormat.ts
+++ b/packages/cli/src/replFormat.ts
@@ -138,6 +138,7 @@ export function formatGroupDetails(
   const group = session.getGroup(groupAlias);
   return [
     `alias=${formatGroupAlias(group.alias)}`,
+    `groupId=${session.deriveGroupId(group.state)}`,
     `coordinator=${formatFullCredentialLabel(group.coordinatorKey)}`,
     `cursor=${colorize(String(group.lastCursor), ansi.bold)}`,
     `messages=${colorize(String(group.messages.length), ansi.bold)}`,
@@ -208,9 +209,12 @@ export function printHelp(): void {
       "  leave",
       "  unwatch <groupAlias>",
       "  add-member <groupAlias> <stablePubkeyOrKeyPackageRef>",
+      "  remove-member <groupAlias> <stablePubkey>",
       "  fetch-welcomes [--coordinator <pubkey>]",
       "  welcomes",
       "  accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--coordinator <pubkey>] [--watch]",
+      "  fetch-join-requests <groupAlias>",
+      "  request-join <gid> [keyPackageAlias] [--coordinator <pubkey>]",
       "  send <message...>    (uses selected group)",
       "  send-to <groupAlias> <message...>",
       "  send-media <filePath> [caption...]   (uses selected group; requires --media-dir)",

--- a/packages/cli/src/replFormat.ts
+++ b/packages/cli/src/replFormat.ts
@@ -188,52 +188,116 @@ export function formatSyncResult(
   return formatChatHistory(session, groupAlias);
 }
 
+export const REPL_COMMAND_HELP = [
+  { names: ["help"], usage: "help" },
+  { names: ["status"], usage: "status" },
+  { names: ["whoami"], usage: "whoami    (prints the private identity key)" },
+  {
+    names: ["gen-kp"],
+    usage:
+      "gen-kp [alias] [--coordinator <pubkey>] [--last-resort] [--local-only]",
+  },
+  {
+    names: ["publish-kp"],
+    usage: "publish-kp <alias> [--coordinator <pubkey>]",
+  },
+  { names: ["key-packages", "kps"], usage: "key-packages | kps" },
+  {
+    names: ["delete-kp"],
+    usage:
+      "delete-kp <aliasOrKeyPackageRef> [--local-only] [--coordinator <pubkey>]",
+  },
+  {
+    names: ["available-kps"],
+    usage: "available-kps [--coordinator <pubkey>]",
+  },
+  {
+    names: ["create-group"],
+    usage:
+      "create-group <alias> [keyPackageAlias] [--coordinator <pubkey>] [--name <value>] [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]... [--watch]",
+  },
+  {
+    names: ["update-group-metadata"],
+    usage:
+      "update-group-metadata <groupAlias> --name <value> [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]...",
+  },
+  {
+    names: ["set-metadata"],
+    usage:
+      "set-metadata <groupAlias> --name <value> [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]...",
+  },
+  { names: ["groups"], usage: "groups" },
+  { names: ["group-info"], usage: "group-info [groupAlias]" },
+  { names: ["group"], usage: "group <groupAlias> [--watch]" },
+  { names: ["use"], usage: "use <groupAlias> [--watch]" },
+  {
+    names: ["leave"],
+    usage: "leave    (clear selection; does not change group membership)",
+  },
+  { names: ["unwatch"], usage: "unwatch <groupAlias>" },
+  {
+    names: ["add-member"],
+    usage: "add-member <groupAlias> <stablePubkeyOrKeyPackageRef>",
+  },
+  {
+    names: ["remove-member"],
+    usage: "remove-member <groupAlias> <stablePubkey>",
+  },
+  {
+    names: ["fetch-welcomes"],
+    usage: "fetch-welcomes [--coordinator <pubkey>]",
+  },
+  { names: ["welcomes"], usage: "welcomes" },
+  {
+    names: ["accept-welcome"],
+    usage:
+      "accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--coordinator <pubkey>] [--watch]",
+  },
+  {
+    names: ["fetch-join-requests"],
+    usage: "fetch-join-requests [groupAlias]",
+  },
+  {
+    names: ["request-join"],
+    usage: "request-join <gid> [keyPackageAlias] [--coordinator <pubkey>]",
+  },
+  { names: ["send"], usage: "send <message...>    (uses selected group)" },
+  { names: ["send-to"], usage: "send-to <groupAlias> <message...>" },
+  {
+    names: ["send-media"],
+    usage:
+      "send-media <filePath> [caption...]   (uses selected group; requires --media-dir)",
+  },
+  {
+    names: ["save-media"],
+    usage:
+      "save-media [groupAlias] <cursor> [destDir]   (decrypts media to destDir, default .)",
+  },
+  { names: ["sync"], usage: "sync [groupAlias]" },
+  { names: ["sync-all"], usage: "sync-all" },
+  { names: ["watch-all"], usage: "watch-all" },
+  { names: ["messages"], usage: "messages [groupAlias]" },
+  { names: ["issues"], usage: "issues [groupAlias]" },
+  { names: ["exit", "quit"], usage: "exit | quit" },
+] as const;
+
 export function printHelp(): void {
   output.write(
     [
       "Commands:",
-      "  help",
-      "  status",
-      "  whoami",
-      "  gen-kp [alias] [--coordinator <pubkey>] [--last-resort] [--local-only]",
-      "  key-packages | kps",
-      "  delete-kp <aliasOrKeyPackageRef> [--local-only] [--coordinator <pubkey>]",
-      "  available-kps [--coordinator <pubkey>]",
-      "  create-group <alias> [keyPackageAlias] [--coordinator <pubkey>] [--name <value>] [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]... [--watch]",
-      "  update-group-metadata <groupAlias> --name <value> [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]...",
-      "  set-metadata <groupAlias> --name <value> [--description <value>] [--icon <value>] [--image-url <value>] [--admin <hex>]...",
-      "  groups",
-      "  group-info [groupAlias]",
-      "  group <groupAlias> [--watch]",
-      "  use <groupAlias> [--watch]",
-      "  leave",
-      "  unwatch <groupAlias>",
-      "  add-member <groupAlias> <stablePubkeyOrKeyPackageRef>",
-      "  remove-member <groupAlias> <stablePubkey>",
-      "  fetch-welcomes [--coordinator <pubkey>]",
-      "  welcomes",
-      "  accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--coordinator <pubkey>] [--watch]",
-      "  fetch-join-requests <groupAlias>",
-      "  request-join <gid> [keyPackageAlias] [--coordinator <pubkey>]",
-      "  send <message...>    (uses selected group)",
-      "  send-to <groupAlias> <message...>",
-      "  send-media <filePath> [caption...]   (uses selected group; requires --media-dir)",
-      "  save-media [groupAlias] <cursor> [destDir]   (decrypts media to destDir, default .)",
-      "  sync [groupAlias]",
-      "  sync-all",
-      "  watch-all",
-      "  messages [groupAlias]",
-      "  issues [groupAlias]",
-      "  exit",
+      ...REPL_COMMAND_HELP.map(({ usage }) => `  ${usage}`),
       "",
       "Key package notes:",
-      "  gen-kp creates a local key package and publishes it immediately unless --local-only is used.",
-      "  Use gen-kp --coordinator <pubkey> to publish the new key package to that coordinator pubkey.",
-      "  Without --coordinator, gen-kp publishes to the session default coordinator.",
+      "  gen-kp creates and publishes immediately unless --local-only is used.",
+      "  publish-kp publishes a previously local-only key package.",
+      "  --coordinator targets a coordinator other than the session default.",
       "",
       "Selected-group shortcuts:",
       "  <Enter> on an empty line => sync",
       "  plain text without a command => send",
+      "",
+      "More documentation:",
+      "  Exit the REPL, then run: cordn docs commands",
       "",
     ].join("\n"),
   );

--- a/packages/cli/src/replFormat.ts
+++ b/packages/cli/src/replFormat.ts
@@ -210,7 +210,7 @@ export function printHelp(): void {
       "  add-member <groupAlias> <stablePubkeyOrKeyPackageRef>",
       "  fetch-welcomes [--coordinator <pubkey>]",
       "  welcomes",
-      "  accept-welcome <keyPackageReference> [groupAlias] [--coordinator <pubkey>] [--watch]",
+      "  accept-welcome <welcomeIdOrKeyPackageReference> [groupAlias] [--coordinator <pubkey>] [--watch]",
       "  send <message...>    (uses selected group)",
       "  send-to <groupAlias> <message...>",
       "  send-media <filePath> [caption...]   (uses selected group; requires --media-dir)",

--- a/packages/cli/src/session.integration.test.ts
+++ b/packages/cli/src/session.integration.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { CliSession } from "./session.ts";
+import { welcomeIdentifier } from "./sessionStore.ts";
 import { FileMediaStore } from "./mediaStore.ts";
 import {
   NoPublishedKeyPackageError,
@@ -85,6 +86,127 @@ describe("CliSession", () => {
       expect(aliceSynced).toHaveLength(1);
       expect(aliceSynced[0]?.content).toBe("hello alice");
       expect(aliceSynced[0]?.sender).toBe(bob.stablePubkey);
+    } finally {
+      await server.transport.close();
+    }
+  });
+
+  test("a restored snapshot acks an accepted welcome instead of re-accepting it", async () => {
+    const relayHub = new MockRelayHub();
+    const serverSigner = new PrivateKeySigner();
+    const serverPubkey = await serverSigner.getPublicKey();
+    const server = await connectServer({
+      signer: serverSigner,
+      relayHandler: relayHub.createRelayHandler(),
+    });
+
+    try {
+      const alice = new CliSession({
+        serverPubkey,
+        relayHandler: relayHub.createRelayHandler(),
+      });
+      const bob = new CliSession({
+        serverPubkey,
+        relayHandler: relayHub.createRelayHandler(),
+      });
+      sessions.push(alice, bob);
+
+      await alice.generateKeyPackage("alice-main");
+      await bob.generateKeyPackage("bob-main");
+      await alice.createGroup("demo", { keyPackageAlias: "alice-main" });
+      const invitation = await alice.addMember("demo", bob.stablePubkey);
+      await alice.syncGroup("demo");
+
+      await bob.fetchWelcomes();
+      await bob.acceptWelcome(invitation.keyPackageReference, "demo");
+      const snapshot = bob.exportSnapshot();
+      await bob.disconnect();
+
+      // Restart: state is restored from the snapshot only.
+      const restoredBob = new CliSession({
+        privateKey: bob.privateKey,
+        serverPubkey,
+        relayHandler: relayHub.createRelayHandler(),
+      });
+      sessions.push(restoredBob);
+      await restoredBob.restoreSnapshot(snapshot);
+
+      // The first fetch after restart delivers the pending consumed-welcome
+      // ack, so the coordinator retires the record instead of re-delivering
+      // it (which previously triggered a duplicate re-join).
+      const welcomes = await restoredBob.fetchWelcomes();
+      expect(welcomes).toEqual([]);
+      expect(await restoredBob.fetchWelcomes()).toEqual([]);
+
+      // The restored session keeps participating in the group.
+      await alice.sendMessage("demo", "after restart");
+      const synced = await restoredBob.syncGroup("demo");
+      expect(synced.at(-1)?.content).toBe("after restart");
+      await restoredBob.sendMessage("demo", "still here");
+      const aliceSynced = await alice.syncGroup("demo");
+      expect(aliceSynced.at(-1)?.content).toBe("still here");
+    } finally {
+      await server.transport.close();
+    }
+  });
+
+  test("accepts multiple Welcomes backed by one last-resort KeyPackage", async () => {
+    const relayHub = new MockRelayHub();
+    const serverSigner = new PrivateKeySigner();
+    const serverPubkey = await serverSigner.getPublicKey();
+    const server = await connectServer({
+      signer: serverSigner,
+      relayHandler: relayHub.createRelayHandler(),
+    });
+
+    try {
+      const alice = new CliSession({
+        serverPubkey,
+        relayHandler: relayHub.createRelayHandler(),
+      });
+      const bob = new CliSession({
+        serverPubkey,
+        relayHandler: relayHub.createRelayHandler(),
+      });
+      const carol = new CliSession({
+        serverPubkey,
+        relayHandler: relayHub.createRelayHandler(),
+      });
+      sessions.push(alice, bob, carol);
+
+      await alice.generateKeyPackage("alice-main", { localOnly: true });
+      const bobLastResort = await bob.generateKeyPackage("bob-last", {
+        lastResort: true,
+      });
+      await carol.generateKeyPackage("carol-main", { localOnly: true });
+      await alice.createGroup("alice-group", {
+        keyPackageAlias: "alice-main",
+      });
+      await carol.createGroup("carol-group", {
+        keyPackageAlias: "carol-main",
+      });
+
+      await alice.addMember("alice-group", bob.stablePubkey);
+      await alice.syncGroup("alice-group");
+      await carol.addMember("carol-group", bob.stablePubkey);
+      await carol.syncGroup("carol-group");
+
+      const welcomes = await bob.fetchWelcomes();
+      expect(welcomes).toHaveLength(2);
+      expect(new Set(welcomes.map((welcome) => welcome.kp_ref))).toEqual(
+        new Set([bobLastResort.keyPackageRef]),
+      );
+
+      await bob.acceptWelcome(welcomeIdentifier(welcomes[0]!), "from-alice");
+      await bob.acceptWelcome(welcomeIdentifier(welcomes[1]!), "from-carol");
+
+      expect(
+        bob
+          .listGroups()
+          .map((group) => group.alias)
+          .sort(),
+      ).toEqual(["from-alice", "from-carol"]);
+      expect(await bob.fetchWelcomes()).toEqual([]);
     } finally {
       await server.transport.close();
     }
@@ -1748,6 +1870,7 @@ describe("CliSession", () => {
       const inviterSync = await alice.syncGroup("demo");
 
       expect(inviterSync).toEqual([]);
+      await alice.sendMessage("demo", "sent while invite was pending");
 
       await bob.fetchWelcomes();
       const joined = await bob.acceptWelcome(
@@ -1756,9 +1879,10 @@ describe("CliSession", () => {
       );
 
       expect(joined.alias).toBe("demo");
-      expect(bob.getGroup("demo").fetchCursor).toBe(1);
-      expect(bob.listSyncIssues("demo")).toEqual([]);
-
+      expect(bob.getGroup("demo").fetchCursor).toBe(2);
+      expect(
+        bob.listMessages("demo").map((message) => message.content),
+      ).toEqual(["sent while invite was pending"]);
       expect(bob.listSyncIssues("demo")).toEqual([]);
     } finally {
       await server.transport.close();
@@ -1812,10 +1936,15 @@ describe("CliSession", () => {
       });
 
       try {
+        await alice.sendMessage("demo", "backlog before watch");
         await bob.watchGroup("demo");
-        await waitForCondition(() => bob.getWatchStatus("demo") === "watching");
 
+        // Awaiting watchGroup includes backlog ingestion before subscription,
+        // so a daemon cannot send on stale state during the connecting seam.
         expect(bob.getWatchStatus("demo")).toBe("watching");
+        expect(
+          bob.listMessages("demo").map((message) => message.content),
+        ).toContain("backlog before watch");
 
         await bob.sendMessage("demo", "hello alice from bob");
         await alice.syncGroup("demo");
@@ -2422,10 +2551,15 @@ describe("CliSession", () => {
       ]);
       expect(
         survivor.listMessages("demo").map((message) => message.content),
-      ).toEqual([
-        `post-reconcile-from-alice-to-${survivorName}`,
-        `post-reconcile-from-bob-to-${survivorName}`,
-      ]);
+      ).toEqual(
+        expect.arrayContaining([
+          "alice-concurrent-1",
+          "bob-concurrent-1",
+          `post-reconcile-from-alice-to-${survivorName}`,
+          `post-reconcile-from-bob-to-${survivorName}`,
+        ]),
+      );
+      expect(survivor.listMessages("demo")).toHaveLength(4);
 
       await alice.syncGroup("demo");
 
@@ -2536,24 +2670,22 @@ describe("CliSession", () => {
           kp_ref: recoveryInvitation.keyPackageReference,
         }),
       ]);
-      await rejectedSession.acceptWelcome(
+      const recoveredGroup = await rejectedSession.acceptWelcome(
         recoveryInvitation.keyPackageReference,
         "demo-recovery",
       );
+      expect(recoveredGroup.alias).toBe("demo");
 
       await bob.sendMessage("demo", `reinvited-${rejectedName}-hello`);
-      const recoveredMessages =
-        await rejectedSession.syncGroup("demo-recovery");
+      const recoveredMessages = await rejectedSession.syncGroup("demo");
 
       expect(recoveredMessages.map((message) => message.content)).toEqual([
         `reinvited-${rejectedName}-hello`,
       ]);
-      expect(rejectedSession.listGroups()).toHaveLength(2);
+      expect(rejectedSession.listGroups()).toHaveLength(1);
 
       for (const session of [alice, bob, survivor, erin, rejectedSession]) {
-        const history = session.listMessages(
-          session === rejectedSession ? "demo-recovery" : "demo",
-        );
+        const history = session.listMessages("demo");
         const cursors = history.map((message) => message.cursor);
         expect(cursors).toEqual([...cursors].sort((a, b) => a - b));
         expect(new Set(cursors).size).toBe(cursors.length);
@@ -2807,8 +2939,12 @@ describe("CliSession", () => {
       expect(carolGroupAMessages).toEqual([]);
       expect(daveGroupBMessages).toEqual([]);
 
-      expect(carol.listMessages("group-a")).toEqual([]);
-      expect(dave.listMessages("group-b")).toEqual([]);
+      expect(
+        carol.listMessages("group-a").map((message) => message.content),
+      ).toEqual(expect.arrayContaining(["a-msg-1", "a-msg-2"]));
+      expect(
+        dave.listMessages("group-b").map((message) => message.content),
+      ).toEqual(expect.arrayContaining(["b-msg-1", "b-msg-2"]));
 
       await carol.generateKeyPackage("carol-race");
       await erin.generateKeyPackage("erin-race");
@@ -3213,8 +3349,22 @@ describe("CliSession", () => {
         expect(new Set(cursors).size).toBe(cursors.length);
       }
 
-      expect(dave.listMessages("group-a")).toEqual([]);
-      expect(frank.listMessages("group-b")).toEqual([]);
+      expect(
+        dave.listMessages("group-a").map((message) => message.content),
+      ).toEqual(
+        expect.arrayContaining([
+          "a-race-msg-from-alice",
+          "a-race-msg-from-bob",
+        ]),
+      );
+      expect(
+        frank.listMessages("group-b").map((message) => message.content),
+      ).toEqual(
+        expect.arrayContaining([
+          "b-race-msg-from-alice",
+          "b-race-msg-from-bob",
+        ]),
+      );
     } finally {
       await server.transport.close();
     }
@@ -3374,15 +3524,16 @@ describe("CliSession", () => {
       await alice.syncAll();
       await bob.syncAll();
       await carol.fetchWelcomes();
-      await carol.acceptWelcome(
+      const carolRejoined = await carol.acceptWelcome(
         carolReinviteIntoA.keyPackageReference,
         "group-a-rejoin",
       );
+      expect(carolRejoined.alias).toBe("group-a");
 
       await bob.sendMessage("group-a", "a-reinvite-msg");
       const carolRejoinSync = await carol.syncAll();
       expect(
-        carolRejoinSync["group-a-rejoin"]?.map((message) => message.content),
+        carolRejoinSync["group-a"]?.map((message) => message.content),
       ).toEqual(["a-reinvite-msg"]);
 
       const frankIntoA = await bob.addMember("group-a", frank.stablePubkey);
@@ -3409,15 +3560,16 @@ describe("CliSession", () => {
       );
       await bob.syncAll();
       await dave.fetchWelcomes();
-      await dave.acceptWelcome(
+      const daveRejoined = await dave.acceptWelcome(
         daveReinviteIntoB.keyPackageReference,
         "group-b-rejoin",
       );
+      expect(daveRejoined.alias).toBe("group-b");
 
       await bob.sendMessage("group-b", "b-post-dave-rejoin");
       const daveRejoinSync = await dave.syncAll();
       expect(
-        daveRejoinSync["group-b-rejoin"]?.map((message) => message.content),
+        daveRejoinSync["group-b"]?.map((message) => message.content),
       ).toEqual(["b-post-dave-rejoin"]);
 
       await expect(
@@ -3433,10 +3585,10 @@ describe("CliSession", () => {
 
       expect(aliceDrain["group-a"] ?? []).toEqual([]);
       expect(bobDrain["group-b"] ?? []).toEqual([]);
-      expect(
-        carolDrain["group-a-rejoin"]?.map((message) => message.content),
-      ).toEqual(expect.arrayContaining(["a-post-frank-join"]));
-      expect(daveDrain["group-b-rejoin"] ?? []).toEqual([]);
+      expect(carolDrain["group-a"]?.map((message) => message.content)).toEqual(
+        expect.arrayContaining(["a-post-frank-join"]),
+      );
+      expect(daveDrain["group-b"] ?? []).toEqual([]);
       expect(
         erinDrain["group-a-erin"]?.map((message) => message.content),
       ).toEqual(
@@ -3463,13 +3615,13 @@ describe("CliSession", () => {
           .listGroups()
           .map((group) => group.alias)
           .sort(),
-      ).toEqual(["group-a", "group-a-rejoin", "group-b-carol"]);
+      ).toEqual(["group-a", "group-b-carol"]);
       expect(
         dave
           .listGroups()
           .map((group) => group.alias)
           .sort(),
-      ).toEqual(["group-b", "group-b-rejoin"]);
+      ).toEqual(["group-b"]);
       expect(erin.listGroups().map((group) => group.alias)).toEqual([
         "group-a-erin",
       ]);
@@ -3483,8 +3635,7 @@ describe("CliSession", () => {
         [bob, "group-a", "a-reinvite-msg", "b-post-carol-join"],
         [bob, "group-b", "b-post-carol-join", "a-reinvite-msg"],
         [carol, "group-a", "a-round-2-from-alice", "b-post-carol-join"],
-        [dave, "group-b", "b-round-2-from-bob", "a-reinvite-msg"],
-        [dave, "group-b-rejoin", "b-post-dave-rejoin", "a-reinvite-msg"],
+        [dave, "group-b", "b-post-dave-rejoin", "a-reinvite-msg"],
         [erin, "group-a-erin", "a-post-erin-join", "b-post-carol-join"],
         [frank, "group-a-frank", "a-post-frank-join", "b-post-carol-join"],
       ] as const) {
@@ -3502,9 +3653,7 @@ describe("CliSession", () => {
         [bob, "group-b"],
         [carol, "group-a"],
         [carol, "group-b-carol"],
-        [carol, "group-a-rejoin"],
         [dave, "group-b"],
-        [dave, "group-b-rejoin"],
         [erin, "group-a-erin"],
         [frank, "group-a-frank"],
       ] as const) {

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -75,7 +75,9 @@ import {
 } from "./pendingEpochOperations.ts";
 import {
   clientStateDecoder,
+  clientStateEncoder,
   encode,
+  keyPackageEncoder,
   makeKeyPackageRef,
   privateKeyPackageEncoder,
 } from "ts-mls";
@@ -139,6 +141,33 @@ export type GroupEvent =
       error?: string;
     };
 
+export interface CliSessionSnapshot {
+  version: 1;
+  privateKey: string;
+  keyPackages: Array<{
+    alias: string;
+    keyPackage: string;
+    privateKeyPackage: string;
+    keyPackageRef: string;
+    keyPackageBase64: string;
+    isLastResort: boolean;
+    publishedAt?: number;
+    consumed: boolean;
+  }>;
+  groups: Array<{
+    alias: string;
+    coordinatorKey: string;
+    clientState: string;
+    status: "active" | "removed";
+    removedAtCursor?: number;
+    lastCursor: number;
+    fetchCursor: number;
+    messages: StoredMessage[];
+    syncIssues: SyncIssue[];
+  }>;
+  welcomes: StoredWelcome[];
+}
+
 interface GroupWatchHandle {
   abort: (reason?: string) => Promise<void>;
   task: Promise<void>;
@@ -170,6 +199,65 @@ export class CliSession {
     this.stablePubkey = deriveStablePubkey(this.privateKey);
     this.mediaStore = options.mediaStore;
     this.onLocalStateAdvance = options.onLocalStateAdvance;
+  }
+
+  exportSnapshot(): CliSessionSnapshot {
+    return {
+      version: 1,
+      privateKey: this.privateKey,
+      keyPackages: this.listKeyPackages().map((entry) => ({
+        ...entry,
+        keyPackage: encodeBase64(encode(keyPackageEncoder, entry.keyPackage)),
+        privateKeyPackage: encodeBase64(
+          encode(privateKeyPackageEncoder, entry.privateKeyPackage),
+        ),
+      })),
+      groups: this.listGroups().map((group) => ({
+        alias: group.alias,
+        coordinatorKey: group.coordinatorKey,
+        clientState: encodeBase64(encode(clientStateEncoder, group.state)),
+        status: group.status,
+        removedAtCursor: group.removedAtCursor,
+        lastCursor: group.lastCursor,
+        fetchCursor: group.fetchCursor,
+        messages: group.messages,
+        syncIssues: group.syncIssues,
+      })),
+      welcomes: this.listWelcomes(),
+    };
+  }
+
+  async restoreSnapshot(snapshot: CliSessionSnapshot): Promise<void> {
+    if (snapshot.version !== 1 || snapshot.privateKey !== this.privateKey) {
+      throw new Error("snapshot identity does not match CLI identity");
+    }
+    for (const entry of snapshot.keyPackages) {
+      this.store.addKeyPackage({
+        ...entry,
+        keyPackage: decodeKeyPackage(decodeBase64(entry.keyPackage)),
+        privateKeyPackage: decodePrivateKeyPackage(
+          decodeBase64(entry.privateKeyPackage),
+        ),
+      });
+    }
+    for (const entry of snapshot.groups) {
+      const decoded = clientStateDecoder(decodeBase64(entry.clientState), 0);
+      if (!decoded) throw new Error(`failed to decode group ${entry.alias}`);
+      const group = this.createGroupSessionState(
+        entry.alias,
+        decoded[0],
+        entry.coordinatorKey,
+      );
+      group.status = entry.status;
+      group.removedAtCursor = entry.removedAtCursor;
+      group.lastCursor = entry.lastCursor;
+      group.fetchCursor = entry.fetchCursor;
+      group.messages = entry.messages;
+      group.syncIssues = entry.syncIssues;
+      group.metadata = getCordnGroupMetadataExtension(decoded[0]);
+      this.store.addGroup(group);
+    }
+    for (const welcome of snapshot.welcomes) this.store.putWelcome(welcome);
   }
 
   /**

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -46,6 +46,7 @@ import {
 import { CoordinatorClientRegistry } from "./coordinatorRegistry.ts";
 import { ingestGroupMessages } from "./groupSync.ts";
 import type { FetchManyPendingJoinRequestsOutput } from "@cordn/core";
+import type { ConsumedJoinRequestRef, ConsumedWelcomeRef } from "@cordn/core";
 import { runGroupWatch } from "./groupWatch.ts";
 import {
   acceptStoredWelcome,
@@ -67,9 +68,9 @@ import type {
 
 import {
   confirmPendingEpochOperations,
+  dropPendingAddMemberForTarget,
   enqueuePendingEpochOperation,
   getPendingEpochOperation,
-  markPendingEpochOperationsConfirmed,
   rejectPendingEpochOperations,
   type PendingEpochOperation,
 } from "./pendingEpochOperations.ts";
@@ -89,11 +90,13 @@ import type {
   Tombstone,
 } from "./multiDevice.ts";
 import {
+  DuplicateGroupAliasError,
   MissingLocalKeyPackageForWelcomeError,
   RemovedFromGroupError,
+  UnknownWelcomeReferenceError,
   SelfRemovalNotSupportedError,
 } from "./sessionErrors.ts";
-import { CliSessionStore } from "./sessionStore.ts";
+import { CliSessionStore, type FetchedJoinRequestRef } from "./sessionStore.ts";
 export type {
   CliSessionOptions,
   ConversationView,
@@ -105,6 +108,16 @@ export type {
   StoredMessage,
   StoredWelcome,
 } from "./sessionState.ts";
+
+function dedupeBy<T>(values: T[], keyOf: (value: T) => string): T[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = keyOf(value);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
 
 export type GroupWatchStatus = "connecting" | "watching" | "errored";
 
@@ -144,6 +157,9 @@ export type GroupEvent =
 export interface CliSessionSnapshot {
   version: 1;
   privateKey: string;
+  /** Default routing config used when the next process starts without
+   *  repeating --server-pubkey/--relay. Optional for older snapshots. */
+  defaultCoordinator?: { serverPubkey: string; relays?: string[] };
   keyPackages: Array<{
     alias: string;
     keyPackage: string;
@@ -166,6 +182,17 @@ export interface CliSessionSnapshot {
     syncIssues: SyncIssue[];
   }>;
   welcomes: StoredWelcome[];
+  /** Epoch operations awaiting Commit re-ingestion. Persisting them keeps an
+   *  add-member Welcome from being stranded across a restart (the Welcome is
+   *  only delivered to the invitee on confirmation). Optional: snapshots from
+   *  earlier builds predate the field. */
+  pendingEpochOperations?: Record<string, PendingEpochOperation[]>;
+  /** Coordinator acknowledgement and fetched-request state. Without it, a
+   *  restart re-delivers handled records for up to the coordinator max age. */
+  acceptedWelcomeIds?: string[];
+  pendingConsumedWelcomes?: Record<string, ConsumedWelcomeRef[]>;
+  fetchedJoinRequests?: Record<string, FetchedJoinRequestRef[]>;
+  pendingConsumedJoinRequests?: Record<string, ConsumedJoinRequestRef[]>;
 }
 
 interface GroupWatchHandle {
@@ -201,10 +228,20 @@ export class CliSession {
     this.onLocalStateAdvance = options.onLocalStateAdvance;
   }
 
+  /** Waits for in-flight group mutations before taking the process-wide
+   *  snapshot, avoiding a pre-Commit state paired with a post-Commit cursor. */
+  async exportSnapshotWhenIdle(): Promise<CliSessionSnapshot> {
+    while (this.groupOperations.size > 0) {
+      await Promise.allSettled([...this.groupOperations.values()]);
+    }
+    return this.exportSnapshot();
+  }
+
   exportSnapshot(): CliSessionSnapshot {
     return {
       version: 1,
       privateKey: this.privateKey,
+      defaultCoordinator: this.coordinatorRegistry.defaultCoordinatorTarget,
       keyPackages: this.listKeyPackages().map((entry) => ({
         ...entry,
         keyPackage: encodeBase64(encode(keyPackageEncoder, entry.keyPackage)),
@@ -224,13 +261,29 @@ export class CliSession {
         syncIssues: group.syncIssues,
       })),
       welcomes: this.listWelcomes(),
+      pendingEpochOperations: Object.fromEntries(this.store.pendingOperations),
+      acceptedWelcomeIds: this.store.listAcceptedWelcomeIds(),
+      pendingConsumedWelcomes: this.store.listPendingConsumedWelcomes(),
+      fetchedJoinRequests: this.store.listFetchedJoinRequests(),
+      pendingConsumedJoinRequests: this.store.listPendingConsumedJoinRequests(),
     };
   }
 
   async restoreSnapshot(snapshot: CliSessionSnapshot): Promise<void> {
-    if (snapshot.version !== 1 || snapshot.privateKey !== this.privateKey) {
+    if (
+      snapshot.version !== 1 ||
+      snapshot.privateKey.toLowerCase() !== this.privateKey.toLowerCase()
+    ) {
       throw new Error("snapshot identity does not match CLI identity");
     }
+    // Transient delivery state first: putWelcome below skips records already
+    // accepted, while restored acks retire them coordinator-side.
+    this.store.restoreTransientState({
+      acceptedWelcomeIds: snapshot.acceptedWelcomeIds,
+      pendingConsumedWelcomes: snapshot.pendingConsumedWelcomes,
+      fetchedJoinRequests: snapshot.fetchedJoinRequests,
+      pendingConsumedJoinRequests: snapshot.pendingConsumedJoinRequests,
+    });
     for (const entry of snapshot.keyPackages) {
       this.store.addKeyPackage({
         ...entry,
@@ -240,6 +293,7 @@ export class CliSession {
         ),
       });
     }
+    const canonicalAliases = new Map<string, string>();
     for (const entry of snapshot.groups) {
       const decoded = clientStateDecoder(decodeBase64(entry.clientState), 0);
       if (!decoded) throw new Error(`failed to decode group ${entry.alias}`);
@@ -255,7 +309,57 @@ export class CliSession {
       group.messages = entry.messages;
       group.syncIssues = entry.syncIssues;
       group.metadata = getCordnGroupMetadataExtension(decoded[0]);
-      this.store.addGroup(group);
+
+      const groupId = this.deriveGroupId(group.state);
+      const existing = this.listGroups().find(
+        (candidate) => this.deriveGroupId(candidate.state) === groupId,
+      );
+      if (!existing) {
+        this.store.addGroup(group);
+        canonicalAliases.set(entry.alias, entry.alias);
+        continue;
+      }
+
+      // Older CLI snapshots could contain one alias per re-invite. Collapse
+      // them to one logical group, keeping the newest epoch and all history.
+      canonicalAliases.set(entry.alias, existing.alias);
+      if (group.state.groupContext.epoch > existing.state.groupContext.epoch) {
+        existing.state = group.state;
+        existing.metadata = group.metadata;
+        existing.coordinatorKey = group.coordinatorKey;
+        existing.status = group.status;
+        existing.removedAtCursor = group.removedAtCursor;
+      }
+      existing.lastCursor = Math.max(existing.lastCursor, group.lastCursor);
+      existing.fetchCursor = Math.max(existing.fetchCursor, group.fetchCursor);
+      existing.messages = dedupeBy(
+        [...existing.messages, ...group.messages],
+        (message) => `${message.cursor}:${message.id}`,
+      ).sort((left, right) => left.cursor - right.cursor);
+      existing.syncIssues = dedupeBy(
+        [...existing.syncIssues, ...group.syncIssues],
+        (issue) => `${issue.cursor}:${issue.detail}`,
+      ).sort((left, right) => left.cursor - right.cursor);
+    }
+    for (const [alias, operations] of Object.entries(
+      snapshot.pendingEpochOperations ?? {},
+    )) {
+      const canonicalAlias = canonicalAliases.get(alias) ?? alias;
+      for (const operation of operations) {
+        if (
+          getPendingEpochOperation(
+            this.store.pendingOperations,
+            canonicalAlias,
+            operation.commitMessageBase64,
+          )
+        ) {
+          continue;
+        }
+        enqueuePendingEpochOperation(this.store.pendingOperations, {
+          ...operation,
+          groupAlias: canonicalAlias,
+        });
+      }
     }
     for (const welcome of snapshot.welcomes) this.store.putWelcome(welcome);
   }
@@ -445,15 +549,6 @@ export class CliSession {
     const keyPackageRef =
       byRef?.keyPackageRef ?? byAlias?.keyPackageRef ?? aliasOrKeyPackageRef;
 
-    let removedLocal = false;
-    if (byRef) {
-      this.store.deleteKeyPackageByRef(keyPackageRef);
-      removedLocal = true;
-    } else if (byAlias) {
-      this.store.deleteKeyPackage(aliasOrKeyPackageRef);
-      removedLocal = true;
-    }
-
     if (!options.localOnly) {
       if (!byRef && !byAlias) {
         const available = await this.listAvailableKeyPackages(
@@ -475,7 +570,12 @@ export class CliSession {
       );
     }
 
-    return { keyPackageRef, removedLocal };
+    // Keep private material until remote deletion succeeds; losing it locally
+    // while the coordinator still advertises the KP strands future Welcomes.
+    if (byRef) this.store.deleteKeyPackageByRef(keyPackageRef);
+    else if (byAlias) this.store.deleteKeyPackage(aliasOrKeyPackageRef);
+
+    return { keyPackageRef, removedLocal: Boolean(byRef || byAlias) };
   }
 
   async createGroup(
@@ -560,6 +660,7 @@ export class CliSession {
       prepared.pendingOperation.postedMsgBase64 = posted.postedMsgBase64;
 
       this.adoptGroupState(group, prepared.newState);
+      prepared.pendingOperation.localStateApplied = true;
 
       // If this add resolved a pending join request the admin had fetched,
       // queue it for retirement on the next fetchPendingJoinRequests. The
@@ -567,6 +668,7 @@ export class CliSession {
       const handledRequest = this.store.findFetchedJoinRequest(
         this.deriveGroupId(group.state),
         prepared.pendingOperation.targetStablePubkey,
+        prepared.keyPackageReference,
       );
       if (handledRequest) {
         this.store.queueConsumedJoinRequest(
@@ -616,6 +718,14 @@ export class CliSession {
       prepared.pendingOperation.postedMsgBase64 = posted.postedMsgBase64;
 
       this.adoptGroupState(group, prepared.newState);
+      prepared.pendingOperation.localStateApplied = true;
+      // If add+remove happen before the add self-echo is finalized, never
+      // deliver a stale Welcome to the member we just removed.
+      dropPendingAddMemberForTarget(
+        this.store.pendingOperations,
+        groupAlias,
+        targetStablePubkey,
+      );
 
       return { targetStablePubkey };
     });
@@ -640,26 +750,27 @@ export class CliSession {
         metadata,
       });
 
-      enqueuePendingEpochOperation(this.store.pendingOperations, {
+      const pendingOperation: PendingEpochOperation = {
         kind: "update-group-metadata",
         groupAlias,
         groupId: this.deriveGroupId(group.state),
         commitMessageBase64: prepared.commitMessageBase64,
+        localStateApplied: false,
         status: "pending",
-      });
+      };
+      enqueuePendingEpochOperation(
+        this.store.pendingOperations,
+        pendingOperation,
+      );
 
       const posted = await this.postOutboundGroupMessage(
         group,
         prepared.commitMessageBase64,
       );
-      const pendingOp = this.store.pendingOperations
-        .get(groupAlias)
-        ?.find((op) => op.commitMessageBase64 === prepared.commitMessageBase64);
-      if (pendingOp) {
-        pendingOp.postedMsgBase64 = posted.postedMsgBase64;
-      }
+      pendingOperation.postedMsgBase64 = posted.postedMsgBase64;
 
       this.adoptGroupState(group, prepared.newState);
+      pendingOperation.localStateApplied = true;
 
       return { metadata: group.metadata ?? metadata };
     });
@@ -667,7 +778,7 @@ export class CliSession {
 
   async fetchWelcomes(coordinatorKey?: string): Promise<StoredWelcome[]> {
     const resolvedCoordinatorKey = this.resolveCoordinatorKey(coordinatorKey);
-    const toAck = this.store.peekConsumedWelcomes();
+    const toAck = this.store.peekConsumedWelcomes(resolvedCoordinatorKey);
     const result = await this.getCoordinatorClient(
       resolvedCoordinatorKey,
     ).FetchPendingWelcomes(
@@ -682,19 +793,19 @@ export class CliSession {
     );
     // Clear only after a successful fetch; a throw leaves the refs queued so
     // the next fetch retries. The ack is idempotent, so re-sends are safe.
-    this.store.clearConsumedWelcomes(toAck);
+    this.store.clearConsumedWelcomes(resolvedCoordinatorKey, toAck);
 
     for (const welcome of result.welcomes) {
-      // Skip welcomes that were already accepted (their kp_ref was deleted
-      // from the local store after acceptance). With non-destructive
-      // FetchPendingWelcomes on the coordinator, the same welcome may be
-      // returned across multiple fetches.
-      if (!this.store.hasWelcome(welcome.kp_ref)) {
-        this.store.putWelcome({
-          ...welcome,
-          coordinatorKey: resolvedCoordinatorKey,
-        });
+      const stored = { ...welcome, coordinatorKey: resolvedCoordinatorKey };
+      // A normal KP is single-use. If an older snapshot lost its consumed ack,
+      // retire the replay instead of presenting it as a fresh invitation.
+      const keyPackage = this.store.findKeyPackageByRef(stored.kp_ref);
+      if (keyPackage?.consumed && !keyPackage.isLastResort) {
+        this.store.retireWelcome(stored, resolvedCoordinatorKey);
+        continue;
       }
+      // Last-resort KPs can back multiple Welcomes, so identity includes `at`.
+      if (!this.store.hasWelcome(stored)) this.store.putWelcome(stored);
     }
 
     return this.listWelcomes();
@@ -763,6 +874,7 @@ export class CliSession {
       groupId,
       result.requests.map((req) => ({
         requesterStablePubkey: req.pk,
+        keyPackageReference: req.kp_ref,
         createdAt: req.at,
       })),
     );
@@ -770,12 +882,18 @@ export class CliSession {
   }
 
   async acceptWelcome(
-    keyPackageReference: string,
+    welcomeIdentifier: string,
     groupAlias?: string,
     coordinatorKey?: string,
   ): Promise<GroupSessionState> {
-    await this.fetchWelcomes(coordinatorKey);
-    const welcome = this.store.getWelcome(keyPackageReference);
+    let welcome: StoredWelcome;
+    try {
+      welcome = this.store.getWelcome(welcomeIdentifier);
+    } catch (error) {
+      if (!(error instanceof UnknownWelcomeReferenceError)) throw error;
+      await this.fetchWelcomes(coordinatorKey);
+      welcome = this.store.getWelcome(welcomeIdentifier);
+    }
     const keyPackage = this.store.findKeyPackageByRef(welcome.kp_ref);
 
     if (!keyPackage) {
@@ -783,9 +901,12 @@ export class CliSession {
     }
 
     const alias = groupAlias ?? `group-${this.store.groupCount + 1}`;
-
-    const group = await acceptStoredWelcome({
-      keyPackageReference,
+    const resolvedCoordinatorKey = this.resolveCoordinatorKey(
+      coordinatorKey ?? welcome.coordinatorKey,
+    );
+    const wasConsumed = keyPackage.consumed;
+    const joined = await acceptStoredWelcome({
+      keyPackageReference: welcome.kp_ref,
       groupAlias: alias,
       welcome,
       keyPackage,
@@ -793,23 +914,72 @@ export class CliSession {
         this.createGroupSessionState(
           resolvedAlias,
           state,
-          this.resolveCoordinatorKey(coordinatorKey ?? welcome.coordinatorKey),
+          resolvedCoordinatorKey,
         ),
     });
-
-    // Use the welcome cursor hint for efficient post-join sync.
-    // If the inviter stored the commit cursor, skip messages sent
-    // before the new member was added.
-    if (welcome.after !== undefined && welcome.after > 0) {
-      group.fetchCursor = welcome.after;
-      group.lastCursor = welcome.after;
+    const groupId = this.deriveGroupId(joined.state);
+    const existing = this.listGroups().find(
+      (candidate) => this.deriveGroupId(candidate.state) === groupId,
+    );
+    if (
+      existing &&
+      existing.state.groupContext.epoch >= joined.state.groupContext.epoch
+    ) {
+      // Exact StoreWelcome retry or stale replay: acknowledge it, but keep the
+      // one local state already representing this group.
+      this.store.deleteWelcome(welcomeIdentifier, resolvedCoordinatorKey);
+      return existing;
     }
 
-    this.store.addGroup(group);
-    await this.establishPostWelcomeBaseline(group, welcome.at);
-    this.store.deleteWelcome(keyPackageReference);
+    let group = joined;
+    if (existing) {
+      // A re-invite/key rotation is a newer state for the same logical group,
+      // not a second conversation. Preserve local history and alias.
+      if (this.isWatching(existing.alias))
+        await this.unwatchGroup(existing.alias);
+      existing.state = joined.state;
+      existing.metadata = joined.metadata;
+      existing.coordinatorKey = resolvedCoordinatorKey;
+      existing.status = "active";
+      existing.removedAtCursor = undefined;
+      this.store.pendingOperations.delete(existing.alias);
+      group = existing;
+    } else {
+      if (this.listGroups().some((candidate) => candidate.alias === alias)) {
+        keyPackage.consumed = wasConsumed;
+        throw new DuplicateGroupAliasError(alias);
+      }
+      this.store.addGroup(group);
+    }
 
-    return this.getGroup(alias);
+    // The inviter's Commit cursor skips traffic from before this leaf joined.
+    if (welcome.after !== undefined && welcome.after > 0) {
+      group.fetchCursor = Math.max(group.fetchCursor, welcome.after);
+      group.lastCursor = Math.max(group.lastCursor, welcome.after);
+    }
+
+    const baseline = await this.runGroupOperation(group.alias, async () => {
+      // Joining is complete once the Welcome is processed. Retire it before
+      // best-effort catch-up so a transient fetch error cannot leave a valid
+      // group paired with a Welcome that looks unaccepted.
+      this.store.deleteWelcome(welcomeIdentifier, resolvedCoordinatorKey);
+      try {
+        return await this.establishPostWelcomeBaseline(group, welcome.at);
+      } catch (error) {
+        const issue: SyncIssue = {
+          cursor: group.fetchCursor,
+          createdAt: Date.now(),
+          detail: `Post-welcome catch-up failed: ${error instanceof Error ? error.message : String(error)}`,
+        };
+        group.syncIssues.push(issue);
+        return { received: [], issues: [issue] };
+      }
+    });
+    if (baseline.received.length > 0 || baseline.issues.length > 0) {
+      this.emitMessageEvent(group.alias, baseline.received, baseline.issues);
+    }
+
+    return group;
   }
 
   async sendMessage(
@@ -971,7 +1141,7 @@ export class CliSession {
   }
 
   async syncGroup(groupAlias: string): Promise<StoredMessage[]> {
-    if (this.isWatching(groupAlias)) {
+    if (this.getWatchStatus(groupAlias) === "watching") {
       return [];
     }
 
@@ -990,12 +1160,22 @@ export class CliSession {
   }
 
   async watchGroup(groupAlias: string): Promise<void> {
-    if (this.watchHandles.has(groupAlias)) {
+    const existing = this.watchHandles.get(groupAlias);
+    if (existing?.status === "errored") {
+      await this.unwatchGroup(groupAlias);
+    } else if (existing) {
       return;
     }
 
     const group = this.getGroup(groupAlias);
+    this.assertGroupIsActive(group);
     const groupId = this.deriveGroupId(group.state);
+    let resolveReady!: () => void;
+    let rejectReady!: (error: unknown) => void;
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
 
     this.watchHandles.set(groupAlias, {
       abort: async () => undefined,
@@ -1017,6 +1197,7 @@ export class CliSession {
         },
         onWatching: () => {
           this.setWatchStatus(groupAlias, "watching");
+          resolveReady();
         },
         onMessages: async (messages) => {
           await this.runGroupOperation(groupAlias, async () => {
@@ -1027,17 +1208,29 @@ export class CliSession {
       },
     });
 
-    const task = watch.task.catch((error) => {
-      const reason = error instanceof Error ? error.message : String(error);
-      this.setWatchStatus(groupAlias, "errored", reason);
-      throw error;
-    });
+    let task!: Promise<void>;
+    task = watch.task
+      .then(() => {
+        if (this.watchHandles.get(groupAlias)?.task === task) {
+          this.setWatchStatus(groupAlias, "errored", "watch stream ended");
+        }
+      })
+      .catch((error) => {
+        const reason = error instanceof Error ? error.message : String(error);
+        this.setWatchStatus(groupAlias, "errored", reason);
+        rejectReady(error);
+        throw error;
+      });
+    // The handle retains the rejection for unwatch/disconnect, while this sink
+    // prevents a background stream failure becoming an unhandled rejection.
+    void task.catch(() => undefined);
 
     const handle = this.watchHandles.get(groupAlias);
     if (handle) {
       handle.abort = watch.abort;
       handle.task = task;
     }
+    await ready;
   }
 
   async unwatchGroup(groupAlias: string): Promise<void> {
@@ -1053,9 +1246,11 @@ export class CliSession {
   }
 
   async watchAllGroups(): Promise<void> {
-    for (const group of this.listGroups()) {
-      await this.watchGroup(group.alias);
-    }
+    await Promise.all(
+      this.listGroups()
+        .filter((group) => group.status !== "removed")
+        .map((group) => this.watchGroup(group.alias).catch(() => undefined)),
+    );
   }
 
   async syncAll(): Promise<Record<string, StoredMessage[]>> {
@@ -1496,7 +1691,7 @@ export class CliSession {
   }
 
   private async catchUpGroupIfNeeded(group: GroupSessionState): Promise<void> {
-    if (this.isWatching(group.alias)) {
+    if (this.getWatchStatus(group.alias) === "watching") {
       return;
     }
 
@@ -1529,8 +1724,6 @@ export class CliSession {
     messages: FetchGroupMessagesOutput["messages"],
     options: {
       suppressIssue?: (issue: SyncIssue) => boolean;
-      finalizePendingOperations?: boolean;
-      recordReceivedMessages?: boolean;
     } = {},
   ): Promise<{
     received: StoredMessage[];
@@ -1539,7 +1732,6 @@ export class CliSession {
     // Process messages one-at-a-time so that state-advancing commits
     // update the exporter secret before subsequent messages from the
     // new epoch are decrypted.
-    const previousMessageCount = group.messages.length;
     const allReceived: StoredMessage[] = [];
     const allIssues: SyncIssue[] = [];
     const allAppliedPending = new Set<string>();
@@ -1596,9 +1788,7 @@ export class CliSession {
         localStablePubkey: this.stablePubkey,
       });
 
-      if (options.recordReceivedMessages !== false) {
-        allReceived.push(...sync.received);
-      }
+      allReceived.push(...sync.received);
       allIssues.push(...sync.issues);
       for (const m of sync.appliedPendingCommitMessages) {
         allAppliedPending.add(m);
@@ -1614,42 +1804,28 @@ export class CliSession {
       }
     }
 
-    if (options.recordReceivedMessages === false) {
-      group.messages.splice(previousMessageCount);
+    // Retry already-confirmed finalizers even when this fetch is empty. A
+    // transient StoreWelcome failure happens after the cursor advances, so the
+    // self-echo will not appear again to trigger another attempt.
+    const finalized = await confirmPendingEpochOperations(
+      this.store.pendingOperations,
+      this.getGroupClient(group),
+      {
+        groupAlias: group.alias,
+        opaqueMessageBase64s: [...allAppliedPending],
+      },
+    );
+    if (finalized > 0) {
+      // A locally-authored Commit just landed on the stream. Notify the
+      // multi-device layer so siblings can fast-forward via a fresh doc.
+      this.notifyLocalStateAdvance();
     }
 
-    // Only mark (don't finalize) when the caller asks for deferred
-    // finalization (e.g. during catch-up before a group operation).
-    if (options.finalizePendingOperations === false) {
-      if (allAppliedPending.size > 0) {
-        markPendingEpochOperationsConfirmed(this.store.pendingOperations, {
-          groupAlias: group.alias,
-          opaqueMessageBase64s: [...allAppliedPending],
-        });
-      }
-    } else {
-      if (allAppliedPending.size > 0) {
-        await confirmPendingEpochOperations(
-          this.store.pendingOperations,
-          this.getGroupClient(group),
-          {
-            groupAlias: group.alias,
-            opaqueMessageBase64s: [...allAppliedPending],
-          },
-        );
-        await this.fetchWelcomes();
-        // A locally-authored Commit just landed on the stream. Notify the
-        // multi-device layer so siblings can fast-forward via a fresh doc
-        // (spec/applications/multi-device.md §10).
-        this.notifyLocalStateAdvance();
-      }
-
-      if (allRejectedPending.size > 0) {
-        await rejectPendingEpochOperations(this.store.pendingOperations, {
-          groupAlias: group.alias,
-          opaqueMessageBase64s: [...allRejectedPending],
-        });
-      }
+    if (allRejectedPending.size > 0) {
+      rejectPendingEpochOperations(this.store.pendingOperations, {
+        groupAlias: group.alias,
+        opaqueMessageBase64s: [...allRejectedPending],
+      });
     }
 
     return {
@@ -1667,14 +1843,15 @@ export class CliSession {
   private async establishPostWelcomeBaseline(
     group: GroupSessionState,
     welcomeCreatedAt: number,
-  ): Promise<void> {
+  ): Promise<{ received: StoredMessage[]; issues: SyncIssue[] }> {
     const result = await this.fetchRawGroupMessages(
       this.deriveGroupId(group.state),
       group.fetchCursor,
     );
 
-    await this.applyIncomingMessages(group, result.messages, {
-      recordReceivedMessages: false,
+    // Pre-join payloads fail exporter decryption and are skipped naturally;
+    // retain decryptable messages sent after the member was added.
+    return this.applyIncomingMessages(group, result.messages, {
       suppressIssue: (issue) =>
         issue.createdAt <= welcomeCreatedAt &&
         (issue.detail ===

--- a/packages/cli/src/sessionErrors.ts
+++ b/packages/cli/src/sessionErrors.ts
@@ -30,8 +30,16 @@ export class UnknownKeyPackageAliasError extends CliSessionError {
 }
 
 export class UnknownWelcomeReferenceError extends CliSessionError {
-  constructor(keyPackageReference: string) {
-    super(`Unknown welcome key package reference: ${keyPackageReference}`);
+  constructor(identifier: string) {
+    super(`Unknown welcome reference: ${identifier}`);
+  }
+}
+
+export class AmbiguousWelcomeReferenceError extends CliSessionError {
+  constructor(identifier: string) {
+    super(
+      `Multiple welcomes use ${identifier}; choose the full <coordinator>:<kp_ref>:<at> identifier`,
+    );
   }
 }
 

--- a/packages/cli/src/sessionSnapshot.test.ts
+++ b/packages/cli/src/sessionSnapshot.test.ts
@@ -1,12 +1,22 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { CliSession } from "./session.ts";
+import { type CliSessionStore, welcomeIdentifier } from "./sessionStore.ts";
+import { enqueuePendingEpochOperation } from "./pendingEpochOperations.ts";
+import type { CoordinatorClientRegistry } from "./coordinatorRegistry.ts";
+
+/** Private-store access for unit tests that drive coordinator ack state
+ *  without a live coordinator. */
+function storeOf(session: CliSession): CliSessionStore {
+  return (session as unknown as { store: CliSessionStore }).store;
+}
 
 describe("CLI session snapshots", () => {
   const serverPubkey = "11".repeat(32);
 
-  test("restores identity and private KeyPackage state", async () => {
-    const original = new CliSession({ serverPubkey });
+  test("restores identity, coordinator config, and private KeyPackage state", async () => {
+    const relays = ["ws://relay.example"];
+    const original = new CliSession({ serverPubkey, relays });
     await original.generateKeyPackage("writer", {
       localOnly: true,
       lastResort: true,
@@ -15,11 +25,13 @@ describe("CLI session snapshots", () => {
     const restored = new CliSession({
       privateKey: original.privateKey,
       serverPubkey,
+      relays,
     });
 
     await restored.restoreSnapshot(snapshot);
 
     expect(restored.stablePubkey).toBe(original.stablePubkey);
+    expect(snapshot.defaultCoordinator).toEqual({ serverPubkey, relays });
     expect(restored.listKeyPackages()).toMatchObject([
       {
         alias: "writer",
@@ -30,6 +42,138 @@ describe("CLI session snapshots", () => {
     ]);
     expect(restored.exportSnapshot()).toEqual(snapshot);
     await Promise.all([original.disconnect(), restored.disconnect()]);
+  });
+
+  test("restores pending epoch operations and coordinator ack state", async () => {
+    const original = new CliSession({ serverPubkey });
+    const store = storeOf(original);
+    const acceptedWelcome = {
+      kp_ref: "ref",
+      welcome_64: "w",
+      at: 1,
+      coordinatorKey: serverPubkey,
+    };
+    store.putWelcome(acceptedWelcome);
+    store.deleteWelcome(welcomeIdentifier(acceptedWelcome), serverPubkey);
+    store.setFetchedJoinRequests("gid", [
+      {
+        requesterStablePubkey: "pk",
+        keyPackageReference: "ref",
+        createdAt: 2,
+      },
+    ]);
+    store.queueConsumedJoinRequest("gid", {
+      requesterStablePubkey: "pk",
+      createdAt: 2,
+    });
+    enqueuePendingEpochOperation(store.pendingOperations, {
+      kind: "add-member",
+      groupAlias: "office",
+      groupId: "gid",
+      commitMessageBase64: "commit",
+      keyPackageReference: "ref",
+      targetStablePubkey: "pk",
+      welcomeBase64: "welcome",
+      status: "pending",
+    });
+
+    const snapshot = original.exportSnapshot();
+    const restored = new CliSession({
+      privateKey: original.privateKey,
+      serverPubkey,
+    });
+    await restored.restoreSnapshot(snapshot);
+
+    const restoredStore = storeOf(restored);
+    // Accepted IDs survive, so the same record cannot be re-added.
+    restoredStore.putWelcome(acceptedWelcome);
+    expect(restoredStore.listWelcomes()).toEqual([]);
+    expect(restoredStore.peekConsumedWelcomes(serverPubkey)).toEqual([
+      { keyPackageReference: "ref", createdAt: 1 },
+    ]);
+    expect(restoredStore.findFetchedJoinRequest("gid", "pk", "ref")).toEqual({
+      requesterStablePubkey: "pk",
+      keyPackageReference: "ref",
+      createdAt: 2,
+    });
+    expect(restoredStore.peekConsumedJoinRequests("gid")).toEqual([
+      { requesterStablePubkey: "pk", createdAt: 2 },
+    ]);
+    expect(restoredStore.pendingOperations.get("office")).toEqual(
+      snapshot.pendingEpochOperations?.["office"],
+    );
+    expect(restored.exportSnapshot()).toEqual(snapshot);
+    await Promise.all([original.disconnect(), restored.disconnect()]);
+  });
+
+  test("collapses legacy duplicate aliases for one group ID", async () => {
+    const original = new CliSession({ serverPubkey });
+    await original.generateKeyPackage("writer", { localOnly: true });
+    await original.createGroup("demo", { keyPackageAlias: "writer" });
+    const snapshot = original.exportSnapshot();
+    const duplicate = {
+      ...snapshot.groups[0]!,
+      alias: "demo-recovery",
+      lastCursor: 3,
+      fetchCursor: 3,
+      messages: [
+        {
+          cursor: 3,
+          createdAt: 1,
+          direction: "inbound" as const,
+          sender: "sender",
+          id: "message",
+          kind: 9,
+          tags: [],
+          content: "recovered",
+        },
+      ],
+    };
+    snapshot.groups.push(duplicate);
+    snapshot.pendingEpochOperations = {
+      "demo-recovery": [
+        {
+          kind: "update-group-metadata",
+          groupAlias: "demo-recovery",
+          groupId: original.deriveGroupId(original.getGroup("demo").state),
+          commitMessageBase64: "commit",
+          status: "pending",
+        },
+      ],
+    };
+    const restored = new CliSession({
+      privateKey: original.privateKey,
+      serverPubkey,
+    });
+
+    await restored.restoreSnapshot(snapshot);
+
+    expect(restored.listGroups().map((group) => group.alias)).toEqual(["demo"]);
+    expect(restored.getGroup("demo").fetchCursor).toBe(3);
+    expect(
+      restored.listMessages("demo").map((message) => message.content),
+    ).toEqual(["recovered"]);
+    expect(
+      storeOf(restored).pendingOperations.get("demo")?.[0]?.groupAlias,
+    ).toBe("demo");
+    await Promise.all([original.disconnect(), restored.disconnect()]);
+  });
+
+  test("keeps local KeyPackage material when remote deletion fails", async () => {
+    const session = new CliSession({ serverPubkey });
+    await session.generateKeyPackage("writer", { localOnly: true });
+    const registry = (
+      session as unknown as { coordinatorRegistry: CoordinatorClientRegistry }
+    ).coordinatorRegistry;
+    vi.spyOn(registry, "getClient").mockReturnValue({
+      RemoveKeyPackages: vi.fn().mockRejectedValue(new Error("offline")),
+    } as never);
+
+    await expect(session.deleteKeyPackage("writer")).rejects.toThrow("offline");
+    expect(session.listKeyPackages().map((entry) => entry.alias)).toEqual([
+      "writer",
+    ]);
+    await session.disconnect();
   });
 
   test("rejects a snapshot belonging to another identity", async () => {

--- a/packages/cli/src/sessionSnapshot.test.ts
+++ b/packages/cli/src/sessionSnapshot.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+
+import { CliSession } from "./session.ts";
+
+describe("CLI session snapshots", () => {
+  const serverPubkey = "11".repeat(32);
+
+  test("restores identity and private KeyPackage state", async () => {
+    const original = new CliSession({ serverPubkey });
+    await original.generateKeyPackage("writer", {
+      localOnly: true,
+      lastResort: true,
+    });
+    const snapshot = original.exportSnapshot();
+    const restored = new CliSession({
+      privateKey: original.privateKey,
+      serverPubkey,
+    });
+
+    await restored.restoreSnapshot(snapshot);
+
+    expect(restored.stablePubkey).toBe(original.stablePubkey);
+    expect(restored.listKeyPackages()).toMatchObject([
+      {
+        alias: "writer",
+        keyPackageRef: original.listKeyPackages()[0]?.keyPackageRef,
+        isLastResort: true,
+        consumed: false,
+      },
+    ]);
+    expect(restored.exportSnapshot()).toEqual(snapshot);
+    await Promise.all([original.disconnect(), restored.disconnect()]);
+  });
+
+  test("rejects a snapshot belonging to another identity", async () => {
+    const original = new CliSession({ serverPubkey });
+    const other = new CliSession({ serverPubkey });
+
+    await expect(
+      other.restoreSnapshot(original.exportSnapshot()),
+    ).rejects.toThrow("snapshot identity does not match CLI identity");
+    await Promise.all([original.disconnect(), other.disconnect()]);
+  });
+});

--- a/packages/cli/src/sessionStore.test.ts
+++ b/packages/cli/src/sessionStore.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "vitest";
 
-import { CliSessionStore } from "./sessionStore.ts";
+import { CliSessionStore, welcomeIdentifier } from "./sessionStore.ts";
 import {
+  AmbiguousWelcomeReferenceError,
   DuplicateGroupAliasError,
   DuplicateKeyPackageAliasError,
   UnknownGroupAliasError,
@@ -73,6 +74,24 @@ describe("CliSessionStore", () => {
     expect(() => store.getWelcome("missing-ref")).toThrow(
       UnknownWelcomeReferenceError,
     );
+  });
+
+  test("keeps multiple last-resort welcomes with the same kp ref", () => {
+    const store = new CliSessionStore();
+    const first = { ...createWelcome("last-resort"), at: 1 };
+    const second = { ...createWelcome("last-resort"), at: 2 };
+    store.putWelcome(first);
+    store.putWelcome(second);
+
+    expect(store.listWelcomes()).toEqual([first, second]);
+    expect(() => store.getWelcome("last-resort")).toThrow(
+      AmbiguousWelcomeReferenceError,
+    );
+    expect(store.getWelcome(welcomeIdentifier(second))).toEqual(second);
+
+    store.deleteWelcome(welcomeIdentifier(first), first.coordinatorKey!);
+    store.putWelcome(first);
+    expect(store.listWelcomes()).toEqual([second]);
   });
 
   test("finds unconsumed key packages and tracks welcome ordering", () => {

--- a/packages/cli/src/sessionStore.ts
+++ b/packages/cli/src/sessionStore.ts
@@ -6,6 +6,7 @@ import type {
 import type { PendingEpochOperation } from "./pendingEpochOperations.ts";
 import type { ConsumedJoinRequestRef, ConsumedWelcomeRef } from "@cordn/core";
 import {
+  AmbiguousWelcomeReferenceError,
   DuplicateGroupAliasError,
   DuplicateKeyPackageAliasError,
   UnknownGroupAliasError,
@@ -13,14 +14,32 @@ import {
   UnknownWelcomeReferenceError,
 } from "./sessionErrors.ts";
 
-const MAX_ACCEPTED_WELCOME_REFS = 1000;
+const MAX_ACCEPTED_WELCOME_IDS = 1000;
 
 function welcomeAckKey(ref: ConsumedWelcomeRef): string {
   return `${ref.keyPackageReference}@${ref.createdAt}`;
 }
 
+/** Stable identifier accepted by CLI commands. `kp_ref` remains accepted when
+ *  it identifies exactly one pending Welcome. */
+export function welcomeIdentifier(
+  welcome: Pick<StoredWelcome, "coordinatorKey" | "kp_ref" | "at">,
+): string {
+  return `${welcome.coordinatorKey?.toLowerCase() ?? "default"}:${welcome.kp_ref}:${welcome.at}`;
+}
+
+function welcomeStorageKey(
+  welcome: Pick<StoredWelcome, "coordinatorKey" | "kp_ref" | "at">,
+): string {
+  return welcomeIdentifier(welcome);
+}
+
 function joinAckKey(ref: ConsumedJoinRequestRef): string {
   return `${ref.requesterStablePubkey}@${ref.createdAt}`;
+}
+
+export interface FetchedJoinRequestRef extends ConsumedJoinRequestRef {
+  keyPackageReference: string;
 }
 
 /** A capped Set that evicts the oldest entry when the cap is exceeded. */
@@ -35,6 +54,11 @@ class CappedRefSet {
 
   has(ref: string): boolean {
     return this.refs.has(ref);
+  }
+
+  /** Insertion-ordered contents, oldest first. */
+  values(): string[] {
+    return [...this.insertionOrder];
   }
 
   add(ref: string): void {
@@ -57,20 +81,19 @@ class CappedRefSet {
 export class CliSessionStore {
   private readonly keyPackages = new Map<string, StoredKeyPackage>();
   private readonly welcomes = new Map<string, StoredWelcome>();
-  private readonly acceptedWelcomeRefs = new CappedRefSet(
-    MAX_ACCEPTED_WELCOME_REFS,
+  private readonly acceptedWelcomeIds = new CappedRefSet(
+    MAX_ACCEPTED_WELCOME_IDS,
   );
-  /** Welcomes accepted locally (joined), awaiting the next fetch's
-   *  `consumed` ack to retire them on the coordinator. */
+  /** Accepted Welcomes awaiting a coordinator-scoped `consumed` ack. */
   private readonly pendingConsumedWelcomes = new Map<
     string,
-    ConsumedWelcomeRef
+    Map<string, ConsumedWelcomeRef>
   >();
-  /** Join requests seen via the last fetch, keyed by groupId then requester
-   *  pk, so addMember can resolve the `createdAt` to ack once handled. */
+  /** Join requests seen via the last fetch, including the kp ref needed to
+   *  match the exact request consumed by addMember. */
   private readonly fetchedJoinRequestsByGroup = new Map<
     string,
-    Map<string, ConsumedJoinRequestRef>
+    Map<string, FetchedJoinRequestRef>
   >();
   /** Join requests handled locally (admin added/rejected), awaiting the next
    *  fetch's `consumed` ack, keyed by groupId then ack key. */
@@ -150,42 +173,43 @@ export class CliSessionStore {
   }
 
   putWelcome(welcome: StoredWelcome): void {
-    // Skip re-adding welcomes whose key package reference was already
-    // accepted (deleted after joining the group).
-    if (this.acceptedWelcomeRefs.has(welcome.kp_ref)) {
-      return;
-    }
-
-    this.welcomes.set(welcome.kp_ref, welcome);
+    const key = welcomeStorageKey(welcome);
+    if (this.acceptedWelcomeIds.has(key)) return;
+    this.welcomes.set(key, welcome);
   }
 
-  hasWelcome(keyPackageReference: string): boolean {
-    return (
-      this.welcomes.has(keyPackageReference) ||
-      this.acceptedWelcomeRefs.has(keyPackageReference)
+  hasWelcome(welcome: StoredWelcome): boolean {
+    const key = welcomeStorageKey(welcome);
+    return this.welcomes.has(key) || this.acceptedWelcomeIds.has(key);
+  }
+
+  getWelcome(identifier: string): StoredWelcome {
+    const matches = this.listWelcomes().filter(
+      (welcome) =>
+        welcomeIdentifier(welcome) === identifier ||
+        welcome.kp_ref === identifier,
     );
+    if (matches.length > 1) {
+      throw new AmbiguousWelcomeReferenceError(identifier);
+    }
+    if (!matches[0]) {
+      throw new UnknownWelcomeReferenceError(identifier);
+    }
+    return matches[0];
   }
 
-  getWelcome(keyPackageReference: string): StoredWelcome {
-    const welcome = this.welcomes.get(keyPackageReference);
-
-    if (!welcome) {
-      throw new UnknownWelcomeReferenceError(keyPackageReference);
-    }
-
-    return welcome;
+  deleteWelcome(identifier: string, coordinatorKey: string): void {
+    this.retireWelcome(this.getWelcome(identifier), coordinatorKey);
   }
 
-  deleteWelcome(keyPackageReference: string): void {
-    const welcome = this.welcomes.get(keyPackageReference);
-    if (welcome) {
-      this.queueConsumedWelcome({
-        keyPackageReference,
-        createdAt: welcome.at,
-      });
-    }
-    this.welcomes.delete(keyPackageReference);
-    this.acceptedWelcomeRefs.add(keyPackageReference);
+  retireWelcome(welcome: StoredWelcome, coordinatorKey: string): void {
+    const key = welcomeStorageKey(welcome);
+    this.queueConsumedWelcome(coordinatorKey, {
+      keyPackageReference: welcome.kp_ref,
+      createdAt: welcome.at,
+    });
+    this.welcomes.delete(key);
+    this.acceptedWelcomeIds.add(key);
   }
 
   listGroups(): GroupSessionState[] {
@@ -234,40 +258,71 @@ export class CliSessionStore {
     return this.pendingEpochOperations;
   }
 
-  queueConsumedWelcome(ref: ConsumedWelcomeRef): void {
-    this.pendingConsumedWelcomes.set(welcomeAckKey(ref), ref);
-  }
-
-  peekConsumedWelcomes(): ConsumedWelcomeRef[] {
-    return [...this.pendingConsumedWelcomes.values()];
-  }
-
-  clearConsumedWelcomes(refs: ConsumedWelcomeRef[]): void {
-    for (const ref of refs) {
-      this.pendingConsumedWelcomes.delete(welcomeAckKey(ref));
+  queueConsumedWelcome(coordinatorKey: string, ref: ConsumedWelcomeRef): void {
+    let bucket = this.pendingConsumedWelcomes.get(coordinatorKey);
+    if (!bucket) {
+      bucket = new Map();
+      this.pendingConsumedWelcomes.set(coordinatorKey, bucket);
     }
+    bucket.set(welcomeAckKey(ref), ref);
   }
 
-  /** Replace the cached pending join requests for a group with the result of
-   *  the latest fetch. */
-  setFetchedJoinRequests(
-    groupId: string,
-    refs: ConsumedJoinRequestRef[],
+  listAcceptedWelcomeIds(): string[] {
+    return this.acceptedWelcomeIds.values();
+  }
+
+  peekConsumedWelcomes(coordinatorKey: string): ConsumedWelcomeRef[] {
+    return [
+      ...(this.pendingConsumedWelcomes.get(coordinatorKey)?.values() ?? []),
+    ];
+  }
+
+  listPendingConsumedWelcomes(): Record<string, ConsumedWelcomeRef[]> {
+    return Object.fromEntries(
+      [...this.pendingConsumedWelcomes.entries()].map(([key, bucket]) => [
+        key,
+        [...bucket.values()],
+      ]),
+    );
+  }
+
+  clearConsumedWelcomes(
+    coordinatorKey: string,
+    refs: ConsumedWelcomeRef[],
   ): void {
-    const byPk = new Map<string, ConsumedJoinRequestRef>();
-    for (const ref of refs) {
-      byPk.set(ref.requesterStablePubkey, ref);
-    }
-    this.fetchedJoinRequestsByGroup.set(groupId, byPk);
+    const bucket = this.pendingConsumedWelcomes.get(coordinatorKey);
+    if (!bucket) return;
+    for (const ref of refs) bucket.delete(welcomeAckKey(ref));
+    if (bucket.size === 0) this.pendingConsumedWelcomes.delete(coordinatorKey);
+  }
+
+  setFetchedJoinRequests(groupId: string, refs: FetchedJoinRequestRef[]): void {
+    this.fetchedJoinRequestsByGroup.set(
+      groupId,
+      new Map(refs.map((ref) => [joinAckKey(ref), ref])),
+    );
   }
 
   findFetchedJoinRequest(
     groupId: string,
     requesterStablePubkey: string,
+    keyPackageReference: string,
   ): ConsumedJoinRequestRef | undefined {
-    return this.fetchedJoinRequestsByGroup
-      .get(groupId)
-      ?.get(requesterStablePubkey);
+    return [...(this.fetchedJoinRequestsByGroup.get(groupId)?.values() ?? [])]
+      .filter(
+        (ref) =>
+          ref.requesterStablePubkey === requesterStablePubkey &&
+          ref.keyPackageReference === keyPackageReference,
+      )
+      .sort((a, b) => b.createdAt - a.createdAt)[0];
+  }
+
+  listFetchedJoinRequests(): Record<string, FetchedJoinRequestRef[]> {
+    return Object.fromEntries(
+      [...this.fetchedJoinRequestsByGroup.entries()].map(
+        ([groupId, bucket]) => [groupId, [...bucket.values()]],
+      ),
+    );
   }
 
   queueConsumedJoinRequest(groupId: string, ref: ConsumedJoinRequestRef): void {
@@ -283,6 +338,14 @@ export class CliSessionStore {
     return [...(this.pendingConsumedJoinRequests.get(groupId)?.values() ?? [])];
   }
 
+  listPendingConsumedJoinRequests(): Record<string, ConsumedJoinRequestRef[]> {
+    return Object.fromEntries(
+      [...this.pendingConsumedJoinRequests.entries()].map(
+        ([groupId, bucket]) => [groupId, [...bucket.values()]],
+      ),
+    );
+  }
+
   clearConsumedJoinRequests(
     groupId: string,
     refs: ConsumedJoinRequestRef[],
@@ -296,6 +359,34 @@ export class CliSessionStore {
     }
     if (bucket.size === 0) {
       this.pendingConsumedJoinRequests.delete(groupId);
+    }
+  }
+
+  /** Restores coordinator acknowledgement state persisted in a snapshot,
+   *  so a restart neither re-delivers nor re-accepts handled records. */
+  restoreTransientState(state: {
+    acceptedWelcomeIds?: string[];
+    pendingConsumedWelcomes?: Record<string, ConsumedWelcomeRef[]>;
+    fetchedJoinRequests?: Record<string, FetchedJoinRequestRef[]>;
+    pendingConsumedJoinRequests?: Record<string, ConsumedJoinRequestRef[]>;
+  }): void {
+    for (const id of state.acceptedWelcomeIds ?? []) {
+      this.acceptedWelcomeIds.add(id);
+    }
+    for (const [coordinatorKey, refs] of Object.entries(
+      state.pendingConsumedWelcomes ?? {},
+    )) {
+      for (const ref of refs) this.queueConsumedWelcome(coordinatorKey, ref);
+    }
+    for (const [groupId, refs] of Object.entries(
+      state.fetchedJoinRequests ?? {},
+    )) {
+      this.setFetchedJoinRequests(groupId, refs);
+    }
+    for (const [groupId, refs] of Object.entries(
+      state.pendingConsumedJoinRequests ?? {},
+    )) {
+      for (const ref of refs) this.queueConsumedJoinRequest(groupId, ref);
     }
   }
 }

--- a/packages/coordinator/CHANGELOG.md
+++ b/packages/coordinator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @cordn/coordinator
 
+## 0.5.4
+
+### Patch Changes
+
+- 1c76cbb: Publish the CLI as the `cordn` npm executable with hosted coordinator defaults and bundled offline documentation. Add encrypted persistent state, non-interactive commands, and a daemon writer with file-based queues. Make queued Welcome identifiers unique and exact StoreWelcome retries idempotent for reusable last-resort KeyPackages.
+
 ## 0.5.3
 
 ### Patch Changes

--- a/packages/coordinator/package.json
+++ b/packages/coordinator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cordn/coordinator",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/coordinator/src/coordinator.test.ts
+++ b/packages/coordinator/src/coordinator.test.ts
@@ -307,8 +307,11 @@ describe("Coordinator welcome flow", () => {
     ).toHaveLength(0);
   });
 
-  test("consumed ack retires a welcome atomically on fetch", async () => {
-    const coordinator = new Coordinator({ cleanupIntervalMs: 0 });
+  test("StoreWelcome retries are idempotent", async () => {
+    const coordinator = new Coordinator({
+      cleanupIntervalMs: 0,
+      now: () => 100,
+    });
     const alice = await createMemberArtifacts(createActor("alice-unit"));
     const bob = await createMemberArtifacts(createActor("bob-unit"));
     const cipherSuite = await getTestCiphersuite();
@@ -323,34 +326,67 @@ describe("Coordinator welcome flow", () => {
       member: bob,
     });
 
-    coordinator.storeWelcome({
-      targetStablePubkey: bob.actor.stablePubkey,
-      keyPackageReference: fixture.keyPackageRefHex,
-      welcome: fixture.welcome,
-    });
+    for (let index = 0; index < 2; index += 1) {
+      coordinator.storeWelcome({
+        targetStablePubkey: bob.actor.stablePubkey,
+        keyPackageReference: fixture.keyPackageRefHex,
+        welcome: fixture.welcome,
+      });
+    }
 
-    const observed = coordinator.fetchPendingWelcomes(
-      bob.actor.stablePubkey,
-    )[0]!;
+    const observed = coordinator.fetchPendingWelcomes(bob.actor.stablePubkey);
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.createdAt).toBe(100);
 
-    // Ack the observed welcome; it is retired and not echoed back.
-    const after = coordinator.fetchPendingWelcomes(bob.actor.stablePubkey, [
-      {
-        keyPackageReference: observed.keyPackageReference,
-        createdAt: observed.createdAt,
-      },
-    ]);
-    expect(after).toHaveLength(0);
-
-    // Re-acking an unknown ref is a no-op (idempotent).
     expect(
       coordinator.fetchPendingWelcomes(bob.actor.stablePubkey, [
         {
-          keyPackageReference: observed.keyPackageReference,
-          createdAt: observed.createdAt,
+          keyPackageReference: observed[0]!.keyPackageReference,
+          createdAt: observed[0]!.createdAt,
         },
       ]),
     ).toHaveLength(0);
+  });
+
+  test("same-millisecond last-resort Welcomes get distinct consumed refs", async () => {
+    const coordinator = new Coordinator({
+      cleanupIntervalMs: 0,
+      now: () => 100,
+    });
+    const alice = await createMemberArtifacts(createActor("alice-unit"));
+    const bob = await createMemberArtifacts(createActor("bob-unit"), {
+      lastResort: true,
+    });
+    const cipherSuite = await getTestCiphersuite();
+    const makeFixture = async (groupId: string) =>
+      createWelcomeForNewMember({
+        senderState: await createGroup({
+          context: {
+            cipherSuite,
+            authService: unsafeTestingAuthenticationService,
+          },
+          groupId: new TextEncoder().encode(groupId),
+          keyPackage: alice.keyPackage,
+          privateKeyPackage: alice.privateKeyPackage,
+        }),
+        member: bob,
+      });
+    const first = await makeFixture("last-resort-one");
+    const second = await makeFixture("last-resort-two");
+
+    for (const fixture of [first, second]) {
+      coordinator.storeWelcome({
+        targetStablePubkey: bob.actor.stablePubkey,
+        keyPackageReference: fixture.keyPackageRefHex,
+        welcome: fixture.welcome,
+      });
+    }
+
+    expect(
+      coordinator
+        .fetchPendingWelcomes(bob.actor.stablePubkey)
+        .map((record) => record.createdAt),
+    ).toEqual([100, 101]);
   });
 
   test("does not delete welcomes regardless of age when maxAgeMs is disabled (0)", async () => {
@@ -747,6 +783,37 @@ describe("Coordinator join request flow", () => {
     ]);
     expect(after).toHaveLength(1);
     expect(after[0]?.requesterStablePubkey).toBe("bob-requester");
+  });
+
+  test("same-requester join requests get distinct consumed refs", () => {
+    const coordinator = new Coordinator({
+      cleanupIntervalMs: 0,
+      now: () => 100,
+    });
+    coordinator.storeJoinRequest({
+      groupId: "group-alpha",
+      requesterStablePubkey: "alice-requester",
+      keyPackageRef: "kp-ref-1",
+    });
+    coordinator.storeJoinRequest({
+      groupId: "group-alpha",
+      requesterStablePubkey: "alice-requester",
+      keyPackageRef: "kp-ref-2",
+    });
+
+    const observed = coordinator.fetchPendingJoinRequests("group-alpha");
+    expect(observed).toEqual([
+      expect.objectContaining({ keyPackageRef: "kp-ref-2", createdAt: 101 }),
+    ]);
+    // An ack captured for the previous request cannot consume the refresh.
+    expect(
+      coordinator.fetchPendingJoinRequests("group-alpha", [
+        {
+          requesterStablePubkey: "alice-requester",
+          createdAt: 100,
+        },
+      ]),
+    ).toEqual(observed);
   });
 
   test("consumed ack retires join requests across groups via fetchMany", () => {

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -18,7 +18,14 @@ import type {
 } from "./types.ts";
 import type { CoordinatorStorage } from "./storage/storage.ts";
 import { InMemoryCoordinatorStorage } from "./storage/inMemoryStorage.ts";
-import { isLastResortKeyPackage } from "@cordn/core";
+import { encodeWelcome, isLastResortKeyPackage } from "@cordn/core";
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
 
 export interface CoordinatorOptions {
   storage?: CoordinatorStorage;
@@ -204,11 +211,30 @@ export class Coordinator {
   }
 
   storeWelcome(input: StoreWelcomeInput): WelcomeQueueRecord {
+    // `consumed` identifies a record by (kp_ref, at). Last-resort KPs are
+    // reusable, so make `at` unique within that target/ref even on millisecond
+    // clocks and across coordinator restarts. ponytail: queues are TTL-bounded;
+    // add a storage max query only if this scan becomes measurable.
+    const pending = this.storage.fetchPendingWelcomes(input.targetStablePubkey);
+    const encodedWelcome = encodeWelcome(input.welcome);
+    const duplicate = pending.find(
+      (record) =>
+        record.keyPackageReference === input.keyPackageReference &&
+        record.joinAfterCursor === input.joinAfterCursor &&
+        bytesEqual(encodeWelcome(record.welcome), encodedWelcome),
+    );
+    if (duplicate) return duplicate;
+
+    const createdAt = pending
+      .filter(
+        (record) => record.keyPackageReference === input.keyPackageReference,
+      )
+      .reduce((at, record) => Math.max(at, record.createdAt + 1), this.now());
     const record: WelcomeQueueRecord = {
       targetStablePubkey: input.targetStablePubkey,
       keyPackageReference: input.keyPackageReference,
       welcome: input.welcome,
-      createdAt: this.now(),
+      createdAt,
       joinAfterCursor: input.joinAfterCursor,
     };
 
@@ -227,11 +253,19 @@ export class Coordinator {
   }
 
   storeJoinRequest(input: StoreJoinRequestInput): JoinRequestRecord {
+    // Join-request acks use (requester pk, at), with the same uniqueness need.
+    const createdAt = this.storage
+      .fetchPendingJoinRequests(input.groupId)
+      .filter(
+        (record) =>
+          record.requesterStablePubkey === input.requesterStablePubkey,
+      )
+      .reduce((at, record) => Math.max(at, record.createdAt + 1), this.now());
     const record: JoinRequestRecord = {
       groupId: input.groupId,
       requesterStablePubkey: input.requesterStablePubkey,
       keyPackageRef: input.keyPackageRef,
-      createdAt: this.now(),
+      createdAt,
     };
 
     return this.storage.storeJoinRequest(record);

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @cordn/server
 
+## 0.5.4
+
+### Patch Changes
+
+- 1c76cbb: Publish the CLI as the `cordn` npm executable with hosted coordinator defaults and bundled offline documentation. Add encrypted persistent state, non-interactive commands, and a daemon writer with file-based queues. Make queued Welcome identifiers unique and exact StoreWelcome retries idempotent for reusable last-resort KeyPackages.
+- Updated dependencies [1c76cbb]
+  - @cordn/coordinator@0.5.4
+
 ## 0.5.3
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cordn/server",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@cordn/test-utils':
         specifier: workspace:*
         version: link:../test-utils
+      esbuild:
+        specifier: ^0.27.7
+        version: 0.27.7
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

- persist CLI identity, KeyPackages, Welcome records, MLS group state, cursors, and message history in an encrypted local snapshot
- support non-interactive commands and a long-running daemon mode
- add atomic file-based inbox and retryable outbox queues for integration with local Unix-style processes
- document the new CLI options and queue formats

## Validation

- `pnpm run test` (307 tests)
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm exec prettier --check packages/cli/src packages/cli/README.md`
- `git diff --check`