### PR TITLE
feat: include sender pubkey with welcomes

### DIFF
--- a/.changeset/welcome-sender-provenance.md
+++ b/.changeset/welcome-sender-provenance.md
@@ -1,0 +1,7 @@
+---
+"@cordn/core": minor
+"@cordn/coordinator": minor
+"@cordn/server": minor
+---
+
+Include the authenticated sender public key with queued welcome records.

--- a/packages/coordinator/src/coordinator.ts
+++ b/packages/coordinator/src/coordinator.ts
@@ -206,6 +206,7 @@ export class Coordinator {
   storeWelcome(input: StoreWelcomeInput): WelcomeQueueRecord {
     const record: WelcomeQueueRecord = {
       targetStablePubkey: input.targetStablePubkey,
+      senderStablePubkey: input.senderStablePubkey,
       keyPackageReference: input.keyPackageReference,
       welcome: input.welcome,
       createdAt: this.now(),

--- a/packages/coordinator/src/storage/sqliteStorage.ts
+++ b/packages/coordinator/src/storage/sqliteStorage.ts
@@ -44,6 +44,7 @@ interface KeyPackageRow {
 
 interface WelcomeRow {
   target_stable_pubkey: string;
+  sender_stable_pubkey: string | null;
   key_package_reference: string;
   welcome_bytes: Buffer;
   created_at: number;
@@ -101,7 +102,7 @@ export class SqliteCoordinatorStorage implements CoordinatorStorage {
     KeyPackageRow
   >;
   private readonly storeWelcomeStatement: Database.Statement<
-    [string, string, Buffer, number, number | null]
+    [string, string | null, string, Buffer, number, number | null]
   >;
   private readonly fetchPendingWelcomesStatement: Database.Statement<
     [string],
@@ -219,6 +220,7 @@ export class SqliteCoordinatorStorage implements CoordinatorStorage {
       CREATE TABLE IF NOT EXISTS welcomes (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         target_stable_pubkey TEXT NOT NULL,
+        sender_stable_pubkey TEXT,
         key_package_reference TEXT NOT NULL,
         welcome_bytes BLOB NOT NULL,
         created_at INTEGER NOT NULL
@@ -250,6 +252,11 @@ export class SqliteCoordinatorStorage implements CoordinatorStorage {
     if (!welcomesColumns.some((col) => col.name === "join_after_cursor")) {
       this.database.exec(
         "ALTER TABLE welcomes ADD COLUMN join_after_cursor INTEGER",
+      );
+    }
+    if (!welcomesColumns.some((col) => col.name === "sender_stable_pubkey")) {
+      this.database.exec(
+        "ALTER TABLE welcomes ADD COLUMN sender_stable_pubkey TEXT",
       );
     }
 
@@ -366,21 +373,22 @@ export class SqliteCoordinatorStorage implements CoordinatorStorage {
       "DELETE FROM key_packages WHERE id = ?",
     );
     this.storeWelcomeStatement = this.database.prepare<
-      [string, string, Buffer, number, number | null]
+      [string, string | null, string, Buffer, number, number | null]
     >(`
       INSERT INTO welcomes (
         target_stable_pubkey,
+        sender_stable_pubkey,
         key_package_reference,
         welcome_bytes,
         created_at,
         join_after_cursor
-      ) VALUES (?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?)
     `);
     this.fetchPendingWelcomesStatement = this.database.prepare<
       [string],
       WelcomeRow & { id: number }
     >(`
-      SELECT id, target_stable_pubkey, key_package_reference, welcome_bytes, created_at, join_after_cursor
+      SELECT id, target_stable_pubkey, sender_stable_pubkey, key_package_reference, welcome_bytes, created_at, join_after_cursor
       FROM welcomes
       WHERE target_stable_pubkey = ?
       ORDER BY id ASC
@@ -694,6 +702,7 @@ export class SqliteCoordinatorStorage implements CoordinatorStorage {
   storeWelcome(record: WelcomeQueueRecord): WelcomeQueueRecord {
     this.storeWelcomeStatement.run(
       record.targetStablePubkey,
+      record.senderStablePubkey ?? null,
       record.keyPackageReference,
       Buffer.from(encodeWelcome(record.welcome)),
       record.createdAt,
@@ -877,6 +886,7 @@ export class SqliteCoordinatorStorage implements CoordinatorStorage {
   private mapWelcomeRow(row: WelcomeRow): WelcomeQueueRecord {
     return {
       targetStablePubkey: row.target_stable_pubkey,
+      senderStablePubkey: row.sender_stable_pubkey ?? undefined,
       keyPackageReference: row.key_package_reference,
       welcome: decodeWelcome(toUint8Array(row.welcome_bytes)),
       createdAt: row.created_at,

--- a/packages/coordinator/src/storage/storage.test.ts
+++ b/packages/coordinator/src/storage/storage.test.ts
@@ -211,6 +211,7 @@ describe.each<StorageFixture>([
 
     coordinator.storeWelcome({
       targetStablePubkey: bob.actor.stablePubkey,
+      senderStablePubkey: alice.actor.stablePubkey,
       keyPackageReference: firstFixture.keyPackageRefHex,
       welcome: firstFixture.welcome,
     });
@@ -229,10 +230,12 @@ describe.each<StorageFixture>([
     expect(fetchedBob[0]?.keyPackageReference).toBe(
       firstFixture.keyPackageRefHex,
     );
+    expect(fetchedBob[0]?.senderStablePubkey).toBe(alice.actor.stablePubkey);
     expect(fetchedCarol).toHaveLength(1);
     expect(fetchedCarol[0]?.keyPackageReference).toBe(
       secondFixture.keyPackageRefHex,
     );
+    expect(fetchedCarol[0]?.senderStablePubkey).toBeUndefined();
 
     // Welcomes survive subsequent fetches (non-destructive).
     expect(

--- a/packages/coordinator/src/types.ts
+++ b/packages/coordinator/src/types.ts
@@ -15,6 +15,7 @@ export interface PublishedKeyPackageRecord {
 
 export interface WelcomeQueueRecord {
   targetStablePubkey: string;
+  senderStablePubkey?: string;
   keyPackageReference: string;
   welcome: Welcome;
   createdAt: number;
@@ -55,6 +56,7 @@ export interface PublishKeyPackageInput {
 
 export interface StoreWelcomeInput {
   targetStablePubkey: string;
+  senderStablePubkey?: string;
   keyPackageReference: string;
   welcome: Welcome;
   joinAfterCursor?: number;

--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -79,6 +79,7 @@ export const pendingWelcomeSchema = z.object({
   welcome_64: z.string(),
   at: z.number(),
   after: z.number().int().positive().optional(),
+  sender_pk: z.string().optional(),
 });
 
 export const consumedWelcomeRefSchema = z.object({

--- a/packages/server/src/coordinatorMethods.ts
+++ b/packages/server/src/coordinatorMethods.ts
@@ -483,15 +483,19 @@ export class CoordinatorAdapter {
           welcome_64: encodeWelcomeBase64(record.welcome),
           at: record.createdAt,
           after: record.joinAfterCursor,
+          sender_pk: record.senderStablePubkey,
         })),
       },
     };
   }
 
-  storeWelcome(input: z.infer<typeof storeWelcomeInputSchema>) {
-    // no extra available here; enforced in registration wrapper
+  storeWelcome(
+    input: z.infer<typeof storeWelcomeInputSchema>,
+    extra: ToolExtra,
+  ) {
     const record = this.coordinator.storeWelcome({
       targetStablePubkey: input.target_pk,
+      senderStablePubkey: requireClientPubkey(extra),
       keyPackageReference: input.kp_ref,
       welcome: decodeWelcomeBase64(input.welcome_64),
       joinAfterCursor: input.after,
@@ -807,8 +811,7 @@ export function registerCoordinatorMethods(
       outputSchema: storeWelcomeOutputSchema,
     },
     withRateLimit(COORDINATOR_METHODS.storeWelcome, (input, extra) => {
-      void extra;
-      return adapter.storeWelcome(input);
+      return adapter.storeWelcome(input, extra);
     }),
   );
 

--- a/packages/server/src/coordinatorServer.test.ts
+++ b/packages/server/src/coordinatorServer.test.ts
@@ -346,11 +346,14 @@ describe("CoordinatorAdapter", () => {
       member: bob,
     });
 
-    const stored = adapter.storeWelcome({
-      target_pk: bob.actor.stablePubkey,
-      kp_ref: group.keyPackageRefHex,
-      welcome_64: encodeWelcomeAsBase64(group.welcome),
-    });
+    const stored = adapter.storeWelcome(
+      {
+        target_pk: bob.actor.stablePubkey,
+        kp_ref: group.keyPackageRefHex,
+        welcome_64: encodeWelcomeAsBase64(group.welcome),
+      },
+      createExtra(alice.actor.stablePubkey),
+    );
 
     expect(stored.content).toEqual([]);
     expect(stored.structuredContent.at).toBeTypeOf("number");
@@ -362,6 +365,9 @@ describe("CoordinatorAdapter", () => {
     expect(fetchedWelcomes.structuredContent.welcomes).toHaveLength(1);
     expect(fetchedWelcomes.structuredContent.welcomes[0]?.kp_ref).toBe(
       group.keyPackageRefHex,
+    );
+    expect(fetchedWelcomes.structuredContent.welcomes[0]?.sender_pk).toBe(
+      alice.actor.stablePubkey,
     );
 
     const messageBytes = await createApplicationMessageBytes({
@@ -446,12 +452,15 @@ describe("CoordinatorAdapter", () => {
     });
 
     // Store with after cursor hint.
-    adapter.storeWelcome({
-      target_pk: bob.actor.stablePubkey,
-      kp_ref: fixture.keyPackageRefHex,
-      welcome_64: encodeWelcomeAsBase64(fixture.welcome),
-      after: 42,
-    });
+    adapter.storeWelcome(
+      {
+        target_pk: bob.actor.stablePubkey,
+        kp_ref: fixture.keyPackageRefHex,
+        welcome_64: encodeWelcomeAsBase64(fixture.welcome),
+        after: 42,
+      },
+      createExtra(alice.actor.stablePubkey),
+    );
 
     // Fetch returns the after cursor.
     const fetched = adapter.fetchPendingWelcomes(
@@ -465,11 +474,14 @@ describe("CoordinatorAdapter", () => {
     });
 
     // Old-style welcome without after returns undefined (backward compat).
-    adapter.storeWelcome({
-      target_pk: bob.actor.stablePubkey,
-      kp_ref: "no-after-ref",
-      welcome_64: encodeWelcomeAsBase64(fixture.welcome),
-    });
+    adapter.storeWelcome(
+      {
+        target_pk: bob.actor.stablePubkey,
+        kp_ref: "no-after-ref",
+        welcome_64: encodeWelcomeAsBase64(fixture.welcome),
+      },
+      createExtra(alice.actor.stablePubkey),
+    );
     const secondFetch = adapter.fetchPendingWelcomes(
       {},
       createExtra(bob.actor.stablePubkey),
@@ -497,11 +509,14 @@ describe("CoordinatorAdapter", () => {
       member: bob,
     });
 
-    adapter.storeWelcome({
-      target_pk: bob.actor.stablePubkey,
-      kp_ref: fixture.keyPackageRefHex,
-      welcome_64: encodeWelcomeAsBase64(fixture.welcome),
-    });
+    adapter.storeWelcome(
+      {
+        target_pk: bob.actor.stablePubkey,
+        kp_ref: fixture.keyPackageRefHex,
+        welcome_64: encodeWelcomeAsBase64(fixture.welcome),
+      },
+      createExtra(alice.actor.stablePubkey),
+    );
 
     const observed = adapter.fetchPendingWelcomes(
       {},


### PR DESCRIPTION
## Summary

- capture the authenticated caller pubkey when storing an MLS Welcome
- return it as the optional `sender_pk` field from `FetchPendingWelcomes`
- persist sender provenance in both coordinator storage implementations
- migrate existing SQLite databases without invalidating legacy Welcome rows

## Compatibility

`sender_pk` is optional in the response schema. Existing queued Welcomes and SQLite rows remain readable and return no sender when provenance was not recorded. New Welcomes stored through the server derive the value from the authenticated transport context rather than client input.

## Verification

- 19 test files / 299 tests pass
- typecheck passes
- build passes
- Prettier check passes
- `git diff --check` passes